### PR TITLE
Much renaming of methods, fields, etc.

### DIFF
--- a/src/main/java/org/example/ansible/vault/Main.java
+++ b/src/main/java/org/example/ansible/vault/Main.java
@@ -34,9 +34,9 @@ public class Main {
         System.out.println("Using temporary folder: " + tempPath);
         System.out.println();
 
-        var encryptedContent = Files.readString(encryptedPath, StandardCharsets.UTF_8);
-        System.out.println("Encrypted content:");
-        System.out.println(encryptedContent);
+        var encryptedString = Files.readString(encryptedPath, StandardCharsets.UTF_8);
+        System.out.println("Encrypted string:");
+        System.out.println(encryptedString);
         System.out.println();
 
         var config = VaultConfiguration.builder()
@@ -47,22 +47,22 @@ public class Main {
 
         var helper = new VaultEncryptionHelper();
 
-        var decryptedValue = helper.getDecryptedKeyValue(encryptedContent, config);
+        var decryptedValue = helper.decryptString(encryptedString, config);
         printDecryptedValue(decryptedValue);
 
         // --- Do several encrypt/decrypt cycles ----
 
-        var secretName = "VaultSecret";
+        var variableName = "MyVaultSecret";
         var plainText = decryptedValue;
 
         for (int i = 1; i <= 5; i++) {
             System.out.printf(
                     "---------- Iteration %d -------------------------------------------------------------------%n%n", i);
 
-            var encryptedValue = helper.getEncryptedValue(plainText, secretName, config);
+            var encryptedValue = helper.encryptString(plainText, variableName, config);
             printEncryptedValue(encryptedValue);
 
-            var reDecryptedValue = helper.getDecryptedKeyValue(encryptedValue, config);
+            var reDecryptedValue = helper.decryptString(encryptedValue, config);
             printDecryptedValue(reDecryptedValue);
 
             plainText = reDecryptedValue;

--- a/src/main/java/org/example/ansible/vault/OsCommandFactory.java
+++ b/src/main/java/org/example/ansible/vault/OsCommandFactory.java
@@ -10,15 +10,21 @@ public class OsCommandFactory {
         this.configuration = configuration;
     }
 
-    public OsCommand getOsCommand(VaultCommandType type, String key, String secretName) {
+    // TODO Not sure it's worth having this entire class at all, since the arguments are so different
+    //  By renaming them to what they are in the encrypt_string and decrypt cases, that becomes very noticeable!
+    //  Plus variableName is only used for encrypt_string
+    public OsCommand getOsCommand(VaultCommandType type,
+                                  String plainTextOrEncryptedFileName,
+                                  String variableName) {
+
         checkArgumentNotNull(type, "type cannot be null");
 
         switch (type) {
-            case ENCRYPT:
-                return VaultEncryptStringCommand.from(configuration, key, secretName);
+            case ENCRYPT_STRING:
+                return VaultEncryptStringCommand.from(configuration, plainTextOrEncryptedFileName, variableName);
 
             case DECRYPT:
-                return VaultDecryptCommand.from(configuration, key);
+                return VaultDecryptCommand.from(configuration, plainTextOrEncryptedFileName);
 
             default:
                 throw new IllegalStateException("Unknown command type: " + type.name());

--- a/src/main/java/org/example/ansible/vault/VaultCommandType.java
+++ b/src/main/java/org/example/ansible/vault/VaultCommandType.java
@@ -1,5 +1,5 @@
 package org.example.ansible.vault;
 
 public enum VaultCommandType {
-    ENCRYPT, DECRYPT
+    ENCRYPT_STRING, DECRYPT
 }

--- a/src/main/java/org/example/ansible/vault/VaultDecryptCommand.java
+++ b/src/main/java/org/example/ansible/vault/VaultDecryptCommand.java
@@ -10,14 +10,13 @@ public class VaultDecryptCommand implements OsCommand {
 
     private final String ansibleVaultPath;
     private final String vaultPasswordFilePath;
-    private final String secretName;
-    private final String encryptedSecretFileName;
+    private final String encryptedFileName;
 
-    public static OsCommand from(VaultConfiguration configuration, String encryptedSecretFileName) {
+    public static OsCommand from(VaultConfiguration configuration, String encryptedFileName) {
         return VaultDecryptCommand.builder()
                 .ansibleVaultPath(configuration.getAnsibleVaultPath())
                 .vaultPasswordFilePath(configuration.getVaultPasswordFilePath())
-                .encryptedSecretFileName(encryptedSecretFileName)
+                .encryptedFileName(encryptedFileName)
                 .build();
     }
 
@@ -28,7 +27,7 @@ public class VaultDecryptCommand implements OsCommand {
                 "decrypt",
                 "--vault-password-file", vaultPasswordFilePath,
                 "--output", "-",
-                Paths.get(encryptedSecretFileName).toString()
+                Paths.get(encryptedFileName).toString()
         );
     }
 }

--- a/src/main/java/org/example/ansible/vault/VaultEncryptStringCommand.java
+++ b/src/main/java/org/example/ansible/vault/VaultEncryptStringCommand.java
@@ -9,15 +9,15 @@ public class VaultEncryptStringCommand implements OsCommand {
 
     private final String ansibleVaultPath;
     private final String vaultPasswordFilePath;
-    private final String secretName;
-    private final String secret;
+    private final String variableName;
+    private final String plainText;
 
-    public static OsCommand from(VaultConfiguration configuration, String key, String secretName) {
+    public static OsCommand from(VaultConfiguration configuration, String plainText, String variableName) {
         return VaultEncryptStringCommand.builder()
                 .ansibleVaultPath(configuration.getAnsibleVaultPath())
                 .vaultPasswordFilePath(configuration.getVaultPasswordFilePath())
-                .secretName(secretName)
-                .secret(key)
+                .variableName(variableName)
+                .plainText(plainText)
                 .build();
     }
 
@@ -25,9 +25,9 @@ public class VaultEncryptStringCommand implements OsCommand {
     public List<String> getOsCommandParts() {
         return List.of(
                 ansibleVaultPath,
-                "encrypt_string", secret,
+                "encrypt_string", plainText,
                 "--vault-password-file", vaultPasswordFilePath,
-                "--name", secretName
+                "--name", variableName
         );
     }
 }

--- a/src/main/java/org/example/ansible/vault/VaultSecretFileDescriptor.java
+++ b/src/main/java/org/example/ansible/vault/VaultSecretFileDescriptor.java
@@ -17,23 +17,23 @@ public class VaultSecretFileDescriptor {
 
     private static final Path DEFAULT_DIRECTORY_PATH = Paths.get("/tmp", "/vms", "encrypted");
 
-    private final String key;
+    private final String encryptedString;
     private final Path directoryPath;
-    private final Path tempKeyFile;
+    private final Path tempFilePath;
     private final String payloadToWrite;
     private final String fileExtension;
 
-    public VaultSecretFileDescriptor(String key, Path directoryPath) {
-        this.key = key;
+    public VaultSecretFileDescriptor(String encryptedString, Path directoryPath) {
+        this.encryptedString = encryptedString;
         this.fileExtension = DEFAULT_FILE_EXTENSION;
         this.directoryPath = directoryPath;
 
-        var keyParts = key.split(":");
-        var keyFileName = keyParts[0];
-        var payload = keyParts[1];
+        var splat = encryptedString.split(":");
+        var variableName = splat[0];
+        var payload = splat[1];
         var newPayload = payload.split("\\" + ANSIBLE_ENCRYPTION_PREAMBLE)[1];
         var cleanedUpPayload = WHITE_SPACE_PATTERN.matcher(newPayload).replaceAll("");
-        this.tempKeyFile = Paths.get(directoryPath.toString(), keyFileName + "." + fileExtension);
+        this.tempFilePath = Paths.get(directoryPath.toString(), variableName + "." + fileExtension);
         this.payloadToWrite = ANSIBLE_ENCRYPTION_PREAMBLE + System.lineSeparator() + cleanedUpPayload;
     }
 }

--- a/src/test/java/org/example/ansible/vault/OsCommandFactoryTest.java
+++ b/src/test/java/org/example/ansible/vault/OsCommandFactoryTest.java
@@ -25,7 +25,7 @@ class OsCommandFactoryTest {
 
     @Test
     void getOsCommand_Encrypt() {
-        var osCommand = factory.getOsCommand(VaultCommandType.ENCRYPT, "My-Secret", "my-secret-name");
+        var osCommand = factory.getOsCommand(VaultCommandType.ENCRYPT_STRING, "My-Secret", "my-secret-name");
 
         assertThat(osCommand).isExactlyInstanceOf(VaultEncryptStringCommand.class);
 


### PR DESCRIPTION
* Rename OsCommandFactory#getOsCommand arguments to match what they
  actually are. Add a TODO, since I think we should just remove this
  entirely
* Rename VaultCommandType#ENCRYPT to ENCRYPT_STRING since it really
  represents the ansible-vault encrypt_string command
* In VaultDecryptCommand, remove secretName since it isn't used, and
  rename encryptedSecretFileName to just encryptedFileName
* In VaultEncryptStringCommand, rename secretName to variableName
  so it aligns more closely with the --name option, and rename
  secret to plainText, since that is what it really is
* In VaultSecretFileDescriptor, rename key to encryptedString,
  rename tempKeyFile to tempFilePath, and rename some local variables
  in the constructor
* Rename VaultEncryptionHelper#getDecryptedKeyValue to decryptString.
  Also rename method arguments to match their purpose better.
* Rename VaultEncryptionHelper#getEncryptedValue to encryptString.
  Also rename method arguments to match their purpose better.
* In VaultEncryptionHelper, rename a bunch of local and internal
  variables and method args to align better with their purpose.

Fixes #8