### PR TITLE
Add integration test for VaultEncryptionHelper

### DIFF
--- a/src/main/java/org/example/ansible/vault/VaultEncryptionHelper.java
+++ b/src/main/java/org/example/ansible/vault/VaultEncryptionHelper.java
@@ -27,12 +27,18 @@ public class VaultEncryptionHelper {
 
     private static final String LINE_SEPARATOR = System.lineSeparator();
 
+    /**
+     * Wraps the ansible-vault encrypt_string command.
+     */
     public String encryptString(String plainText, String variableName, VaultConfiguration configuration) {
         validateEncryptionConfiguration(configuration);
         var osCommand = VaultEncryptStringCommand.from(configuration, plainText, variableName);
         return executeVaultCommand(osCommand);
     }
 
+    /**
+     * Decrypts an encrypted string variable formatted using encrypt_string with a --name option.
+     */
     public String decryptString(String encryptedString, VaultConfiguration configuration) {
         validateEncryptionConfiguration(configuration);
 
@@ -66,6 +72,7 @@ public class VaultEncryptionHelper {
     private void writeEncryptStringContentToTempFile(VaultEncryptedVariable encryptedVariable,
                                                      Path tempFilePath) {
 
+        // TODO Why don't we just use Files.writeString or Files.write???
         try (var outputStream = newBufferedOutputStream(tempFilePath)) {
             var bytes = encryptedVariable.getEncryptedFileBytes();
             var inputStream = new BufferedInputStream(new ByteArrayInputStream(bytes));

--- a/src/test/java/org/example/ansible/vault/VaultEncryptedVariableTest.java
+++ b/src/test/java/org/example/ansible/vault/VaultEncryptedVariableTest.java
@@ -3,6 +3,9 @@ package org.example.ansible.vault;
 import static java.util.stream.Collectors.toUnmodifiableList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
+import static org.junit.jupiter.api.condition.OS.LINUX;
+import static org.junit.jupiter.api.condition.OS.MAC;
+import static org.junit.jupiter.api.condition.OS.SOLARIS;
 
 import org.example.ansible.vault.testing.Fixtures;
 import org.junit.jupiter.api.BeforeEach;
@@ -11,7 +14,6 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.RepeatedTest;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledOnOs;
-import org.junit.jupiter.api.condition.OS;
 import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
@@ -30,7 +32,7 @@ class VaultEncryptedVariableTest {
      * (limitation is because Java requires a constant value in annotation values)
      */
     @Nested
-    @EnabledOnOs({OS.LINUX, OS.MAC, OS.SOLARIS})
+    @EnabledOnOs({LINUX, MAC, SOLARIS})
     class Constructor {
 
         @Nested

--- a/src/test/java/org/example/ansible/vault/VaultEncryptionHelperIntegrationTest.java
+++ b/src/test/java/org/example/ansible/vault/VaultEncryptionHelperIntegrationTest.java
@@ -1,0 +1,106 @@
+package org.example.ansible.vault;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+import static org.junit.jupiter.api.condition.OS.LINUX;
+import static org.junit.jupiter.api.condition.OS.MAC;
+
+import org.apache.commons.lang3.SystemUtils;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.condition.EnabledOnOs;
+import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Optional;
+
+/**
+ * This test only runs on Linux or macOS, and only then if ansible-vault is actually installed
+ * in one of the expected locations.
+ */
+@DisplayName("VaultEncryptionHelper (Integration Test)")
+@EnabledOnOs({LINUX, MAC})
+class VaultEncryptionHelperIntegrationTest {
+
+    // Location expected on macOS; assuming installed via Homebrew
+    private static final String MACOS_HOMEBREW_ANSIBLE_PATH = "/usr/local/bin/ansible-vault";
+
+    // Location expected on Linux; expected installed via yum, apt-get, etc.
+    private static final String LINUX_ANSIBLE_PATH = "/usr/bin/ansible-vault";
+
+    private static final String PASSWORD = "password100";
+
+    private static String ansibleVaultFile;
+
+    @BeforeAll
+    static void beforeAll() {
+        ansibleVaultFile = pathOfAnsibleVault().orElse("/dummy/ansible-vault");
+        assumeTrue(Files.exists(Path.of(ansibleVaultFile)), "ansible-vault not found");
+    }
+
+    private static Optional<String> pathOfAnsibleVault() {
+        if (SystemUtils.IS_OS_MAC) {
+            return Optional.of(MACOS_HOMEBREW_ANSIBLE_PATH);
+        } else if (SystemUtils.IS_OS_LINUX) {
+            return Optional.of(LINUX_ANSIBLE_PATH);
+        }
+        return Optional.empty();
+    }
+
+    private VaultEncryptionHelper helper;
+    private VaultConfiguration config;
+
+    @TempDir
+    Path tempDirPath;
+
+    @BeforeEach
+    void setUp() throws IOException {
+        helper = new VaultEncryptionHelper();
+        var tempDir = tempDirPath.toString();
+
+        var passwordFilePath = Path.of(tempDir, ".vault_pass");
+        Files.writeString(passwordFilePath, PASSWORD);
+
+        config = VaultConfiguration.builder()
+                .ansibleVaultPath(ansibleVaultFile)
+                .vaultPasswordFilePath(passwordFilePath.toString())
+                .tempDirectory(tempDir)
+                .build();
+    }
+
+    @Nested
+    class EncryptString {
+
+        @ParameterizedTest
+        @CsvSource({
+                "my_password,password,1-2-3-4-5",
+                "the_answer,42",
+                "some_variable,67890-12345"
+        })
+        void shouldEncryptStringInValidFormat(String variableName, String plainText) {
+            var encryptedString = helper.encryptString(plainText, variableName, config);
+            var variable = new VaultEncryptedVariable(encryptedString);
+
+            assertThat(variable.getVariableName()).isEqualTo(variableName);
+        }
+
+        @ParameterizedTest
+        @CsvSource({
+                "my_password,this is my password",
+                "secret_variable,42",
+                "another_variable,12345"
+        })
+        void shouldEncryptAndDecryptStrings(String variableName, String plainText) {
+            var encryptedString = helper.encryptString(plainText, variableName, config);
+            var decryptedString = helper.decryptString(encryptedString, config);
+
+            assertThat(decryptedString).isEqualTo(plainText);
+        }
+    }
+}

--- a/src/test/java/org/example/ansible/vault/VaultEncryptionHelperTest.java
+++ b/src/test/java/org/example/ansible/vault/VaultEncryptionHelperTest.java
@@ -31,6 +31,8 @@ import java.nio.file.Path;
 // so we need to think about how/if we can make it better. Could we detect if ansible-vault
 // is available, or assume a known location and if present use it and test using the
 // actual command?
+//
+// TODO How can this be improved so as not to mock too much but without needing ansible-vault installed?
 
 @DisplayName("VaultEncryptionHelper")
 class VaultEncryptionHelperTest {


### PR DESCRIPTION
* Add VaultEncryptionHelperIntegrationTest, which only works if
  ansible-vault is installed and in the expected location for
  Linux and macOS operating systems
* Add minimal Javadoc and a TODO to VaultEncryptionHelper
* Use static import on the OS enum values in VaultEncryptedVariableTest
* Add YAT (yet another TODO) in VaultEncryptionHelperTest

Fixes #6