### PR TITLE
Decrypt to new file should not allow output file same as input file

### DIFF
--- a/src/main/java/org/example/ansible/vault/VaultEncryptionHelper.java
+++ b/src/main/java/org/example/ansible/vault/VaultEncryptionHelper.java
@@ -2,6 +2,7 @@ package org.example.ansible.vault;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static org.apache.commons.lang3.StringUtils.isBlank;
+import static org.kiwiproject.base.KiwiPreconditions.checkArgumentNotBlank;
 import static org.kiwiproject.base.KiwiStrings.f;
 import static org.kiwiproject.base.KiwiStrings.format;
 import static org.kiwiproject.logging.LazyLogParameterSupplier.lazy;
@@ -68,6 +69,9 @@ public class VaultEncryptionHelper {
     public Path decryptFile(String encryptedFilePath,
                             String outputFilePath,
                             VaultConfiguration configuration) {
+        checkArgument(!outputFilePath.equalsIgnoreCase(encryptedFilePath),
+                "outputFilePath must be different than encryptedFilePath (case-insensitive)");
+
         validateEncryptionConfiguration(configuration);
         var osCommand = VaultDecryptCommand.from(configuration, encryptedFilePath, outputFilePath);
         executeVaultCommandWithoutOutput(osCommand, encryptedFilePath);
@@ -109,6 +113,8 @@ public class VaultEncryptionHelper {
      */
     public String decryptString(String encryptedString, VaultConfiguration configuration) {
         validateEncryptionConfiguration(configuration);
+        checkArgumentNotBlank(configuration.getTempDirectory(),
+                "configuration.tempDirectory is required for decryptString");
 
         var encryptedVariable = new VaultEncryptedVariable(encryptedString);
         var tempFilePath = encryptedVariable.generateRandomFilePath(configuration.getTempDirectory());

--- a/src/test/java/org/example/ansible/vault/VaultEncryptionHelperTest.java
+++ b/src/test/java/org/example/ansible/vault/VaultEncryptionHelperTest.java
@@ -2,6 +2,7 @@ package org.example.ansible.vault;
 
 import static java.util.Objects.isNull;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.example.ansible.vault.Utils.subListExcludingLast;
 import static org.mockito.ArgumentMatchers.any;
@@ -21,6 +22,8 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 import org.kiwiproject.base.process.ProcessHelper;
 import org.kiwiproject.collect.KiwiLists;
 
@@ -263,6 +266,18 @@ class VaultEncryptionHelperTest {
 
                 var command = VaultDecryptCommand.from(configuration, encryptedFile, outputFile);
                 verify(processHelper).launch(command.getCommandParts());
+            }
+
+            @ParameterizedTest
+            @CsvSource({
+                    "/data/crypt/secrets.yml,/data/crypt/secrets.yml",
+                    "/data/crypt/secrets.yml,/data/crypt/Secrets.yml",
+                    "/data/crypt/secrets.yml,/data/crypt/SECRETS.yml"
+            })
+            void shouldNotPermitNewFileLocationToOverwriteEncryptedFile(String encryptedFile, String outputFile) {
+                assertThatIllegalArgumentException()
+                        .isThrownBy(() -> helper.decryptFile(encryptedFile, outputFile, configuration))
+                        .withMessage("outputFilePath must be different than encryptedFilePath (case-insensitive)");
             }
 
             @Test


### PR DESCRIPTION
* Make sure the encryptedFilePath and outputFilePath are different
  in a case-insensitive manner

Should have been done as part of #10