### PR TITLE
Support viewing vault-encrypted files

### DIFF
--- a/src/main/java/org/example/ansible/vault/VaultViewCommand.java
+++ b/src/main/java/org/example/ansible/vault/VaultViewCommand.java
@@ -1,0 +1,32 @@
+package org.example.ansible.vault;
+
+import lombok.Builder;
+
+import java.nio.file.Paths;
+import java.util.List;
+
+@Builder
+public class VaultViewCommand implements OsCommand {
+
+    private final String ansibleVaultPath;
+    private final String vaultPasswordFilePath;
+    private final String encryptedFilePath;
+
+    public static VaultViewCommand from(VaultConfiguration configuration, String encryptedFilePath) {
+        return VaultViewCommand.builder()
+                .ansibleVaultPath(configuration.getAnsibleVaultPath())
+                .vaultPasswordFilePath(configuration.getVaultPasswordFilePath())
+                .encryptedFilePath(encryptedFilePath)
+                .build();
+    }
+
+    @Override
+    public List<String> getCommandParts() {
+        return List.of(
+                ansibleVaultPath,
+                "view",
+                "--vault-password-file", vaultPasswordFilePath,
+                Paths.get(encryptedFilePath).toString()
+        );
+    }
+}

--- a/src/test/java/org/example/ansible/vault/VaultViewCommandTest.java
+++ b/src/test/java/org/example/ansible/vault/VaultViewCommandTest.java
@@ -1,0 +1,36 @@
+package org.example.ansible.vault;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("VaultViewCommand")
+class VaultViewCommandTest {
+
+    private VaultConfiguration configuration;
+
+    @BeforeEach
+    void setUp() {
+        configuration = VaultConfiguration.builder()
+                .ansibleVaultPath("/usr/bin/ansible-vault")
+                .vaultPasswordFilePath("~/.ansible/vault_pass")
+                .build();
+    }
+
+    @Test
+    void shouldBuildCommand() {
+        var encryptedFileName = "/data/crypt/passwords.txt";
+
+        var command = VaultViewCommand.from(configuration, encryptedFileName);
+
+        assertThat(command.getCommandParts()).containsExactly(
+                configuration.getAnsibleVaultPath(),
+                "view",
+                "--vault-password-file",
+                configuration.getVaultPasswordFilePath(),
+                encryptedFileName
+        );
+    }
+}


### PR DESCRIPTION
* Add viewFile in VaultEncryptionHelper
* Extract common code to execute a process into executeVaultCommand
* Add TODO in VaultEncryptionHelper to replace the original process
  handling code (now renamed executeVaultCommandReturningStdoutOld)
  with the new executeVaultCommandReturningStdout which has better
  process and error handling
* Add VaultViewCommand

Fixes #32