### PR TITLE
Refactor decryptString in VaultEncryptionHelper

### DIFF
--- a/src/main/java/org/example/ansible/vault/VaultEncryptionHelper.java
+++ b/src/main/java/org/example/ansible/vault/VaultEncryptionHelper.java
@@ -143,7 +143,7 @@ public class VaultEncryptionHelper {
             createTempDirectoryIfNecessary(Path.of(configuration.getTempDirectory()));
             writeEncryptStringContentToTempFile(encryptedVariable, tempFilePath);
             var osCommand = VaultDecryptCommand.toStdoutFrom(configuration, tempFilePath.toString());
-            return executeVaultCommandReturningStdoutOld(osCommand);
+            return executeVaultCommandReturningStdout(osCommand);
         } catch (Exception e) {
             LOG.error("Error decrypting", e);
             throw e;


### PR DESCRIPTION
* Change decryptString in VaultEncryptionHelper to use the new
  executeVaultCommandReturningStdout
* Disable a bunch of existing tests, replacing them with new tests that
  use the process mocking that the other new tests use
* Forgot to do verifications of the calls in the encryptString tests,
  so add verification of the encrypt_string command