### PR TITLE
Remove obsolete code and disabled tests from VaultEncryptionHelper/Test

### DIFF
--- a/src/main/java/org/example/ansible/vault/Utils.java
+++ b/src/main/java/org/example/ansible/vault/Utils.java
@@ -2,16 +2,43 @@ package org.example.ansible.vault;
 
 import lombok.experimental.UtilityClass;
 
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.UncheckedIOException;
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 
 @UtilityClass
 class Utils {
 
-    public static List<String> subListExcludingLast(List<String> input) {
+    // Consider:
+    // - moving subList methods into KiwiLists
+    // - moving readProcessXxx methods into KiwiIO
+
+    static List<String> subListExcludingLast(List<String> input) {
         return input.subList(0, input.size() - 1);
     }
 
-    public static List<String> subListFrom(List<String> input, int number) {
+    static List<String> subListFrom(List<String> input, int number) {
         return input.subList(number - 1, input.size());
+    }
+
+    static String readProcessOutput(Process process) {
+        return readInputStreamAsString(process.getInputStream());
+    }
+
+    static String readProcessErrorOutput(Process process) {
+        return readInputStreamAsString(process.getErrorStream());
+    }
+
+    static String readInputStreamAsString(InputStream inputStream) {
+        try {
+            var outputStream = new ByteArrayOutputStream();
+            inputStream.transferTo(outputStream);
+            return outputStream.toString(StandardCharsets.UTF_8);
+        } catch (IOException e) {
+            throw new UncheckedIOException("Error converting InputStream to String", e);
+        }
     }
 }

--- a/src/main/java/org/example/ansible/vault/VaultConfiguration.java
+++ b/src/main/java/org/example/ansible/vault/VaultConfiguration.java
@@ -1,6 +1,7 @@
 package org.example.ansible.vault;
 
-import lombok.AllArgsConstructor;
+import static java.util.Objects.isNull;
+
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -8,15 +9,21 @@ import lombok.Setter;
 
 @Getter
 @Setter
-@Builder
 @NoArgsConstructor
-@AllArgsConstructor
 public class VaultConfiguration {
 
     private String ansibleVaultPath;
     private String vaultPasswordFilePath;
-
-    // TODO Should this default to the user's tmp dir?
     private String tempDirectory;
 
+    @Builder
+    public VaultConfiguration(String ansibleVaultPath, String vaultPasswordFilePath, String tempDirectory) {
+        this.ansibleVaultPath = ansibleVaultPath;
+        this.vaultPasswordFilePath = vaultPasswordFilePath;
+        this.tempDirectory = isNull(tempDirectory) ? getJavaTempDir() : tempDirectory;
+    }
+
+    private String getJavaTempDir() {
+        return System.getProperty("java.io.tmpdir");
+    }
 }

--- a/src/test/java/org/example/ansible/vault/VaultConfigurationTest.java
+++ b/src/test/java/org/example/ansible/vault/VaultConfigurationTest.java
@@ -1,0 +1,31 @@
+package org.example.ansible.vault;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("VaultConfiguration")
+class VaultConfigurationTest {
+
+    @Test
+    void shouldUseTempDirectoryIfSupplied() {
+        var config = VaultConfiguration.builder()
+                .ansibleVaultPath("/usr/bin/ansible-vault")
+                .vaultPasswordFilePath("/data/vault/.vault_pass")
+                .tempDirectory("/data/vault/tmp")
+                .build();
+
+        assertThat(config.getTempDirectory()).isEqualTo("/data/vault/tmp");
+    }
+
+    @Test
+    void shouldAssignTempDirectoryIfNotSupplied() {
+        var config = VaultConfiguration.builder()
+                .ansibleVaultPath("/usr/bin/ansible-vault")
+                .vaultPasswordFilePath("/data/vault/.vault_pass")
+                .build();
+
+        assertThat(config.getTempDirectory()).isEqualTo(System.getProperty("java.io.tmpdir"));
+    }
+}


### PR DESCRIPTION
* Remove disabled tests from VaultEncryptionHelperTest
* Refactor common setup code in VaultEncryptionHelperTest
* Remove (now obsolete) code from VaultEncryptionHelper:
  - executeVaultCommandReturningStdoutOld
  - launchProcess
* Change visibility of methods to private in VaultEncryptionHelper
  for all methods where that is possible to do without breaking things

Misc:

* Make VaultConfiguration set the tempDirectory to the Java temp
  directory if it is not specified.
* Move several generic I/O utility methods from VaultEncryptionHelper
  into Utils
* Re-order some methods in VaultEncryptionHelper based on when they
  are used
* Reduce visibility of Utils methods to package-private