### PR TITLE
Rename format to formatVersion in VaultEncryptedVariable

### DIFF
--- a/src/main/java/org/example/ansible/vault/VaultEncryptedVariable.java
+++ b/src/main/java/org/example/ansible/vault/VaultEncryptedVariable.java
@@ -37,7 +37,7 @@ class VaultEncryptedVariable {
     private static final String LINE_SEPARATOR = System.lineSeparator();
 
     private String variableName;
-    private String format;
+    private String formatVersion;
     private String cipher;
     @Getter(AccessLevel.NONE) private String vaultIdLabel;
     private List<String> encryptedContentLines;
@@ -67,7 +67,7 @@ class VaultEncryptedVariable {
     }
 
     // line 2 should be:
-    // <10 spaces>$ANSIBLE_VAULT;<format>;<cipher>[;<vault-id-label]
+    // <10 spaces>$ANSIBLE_VAULT;<format-version>;<cipher>[;<vault-id-label]
     private void parseLine2(List<String> lines) {
         var second = KiwiLists.second(lines);
         checkArgument(second.contains(";"), INVALID_ANSIBLE_VAULT_DECLARATION);
@@ -75,8 +75,8 @@ class VaultEncryptedVariable {
         var splat = second.split(";");
         checkArgument(line2HasValidLength(splat) && line2HasValidPrefix(splat[0]), INVALID_ANSIBLE_VAULT_DECLARATION);
 
-        checkArgument(isValidFormat(splat[1]), INVALID_ANSIBLE_VAULT_DECLARATION);
-        this.format = splat[1];
+        checkArgument(isValidFormatVersion(splat[1]), INVALID_ANSIBLE_VAULT_DECLARATION);
+        this.formatVersion = splat[1];
 
         checkArgumentNotBlank(splat[2], INVALID_ANSIBLE_VAULT_DECLARATION);
         this.cipher = splat[2];
@@ -95,7 +95,7 @@ class VaultEncryptedVariable {
         return parts.length == 3 || parts.length == 4;
     }
 
-    private static boolean isValidFormat(String value) {
+    private static boolean isValidFormatVersion(String value) {
         return "1.1".equals(value) || "1.2".equals(value);
     }
 
@@ -117,7 +117,7 @@ class VaultEncryptedVariable {
     }
 
     private String encryptedFileFirstLine() {
-        return "$ANSIBLE_VAULT;" + format + ";" + cipher + vaultIdLabelFragmentOrEmpty();
+        return "$ANSIBLE_VAULT;" + formatVersion + ";" + cipher + vaultIdLabelFragmentOrEmpty();
     }
 
     private String vaultIdLabelFragmentOrEmpty() {

--- a/src/test/java/org/example/ansible/vault/VaultEncryptedVariableTest.java
+++ b/src/test/java/org/example/ansible/vault/VaultEncryptedVariableTest.java
@@ -104,8 +104,8 @@ class VaultEncryptedVariableTest {
                 "1.1, db_password",
                 "1.2, some_password"
         })
-        void shouldParseVariableName(String format, String expectedVariableName) {
-            var encryptString = fixtureWithFormat(format);
+        void shouldParseVariableName(String formatVersion, String expectedVariableName) {
+            var encryptString = fixtureWithFormatVersion(formatVersion);
             var vaultEncryptedVariable = new VaultEncryptedVariable(encryptString);
 
             assertThat(vaultEncryptedVariable.getVariableName()).isEqualTo(expectedVariableName);
@@ -113,11 +113,11 @@ class VaultEncryptedVariableTest {
 
         @ParameterizedTest
         @ValueSource(strings = {"1.1", "1.2"})
-        void shouldParseFormat(String format) {
-            var encryptString = fixtureWithFormat(format);
+        void shouldParseFormatVersion(String formatVersion) {
+            var encryptString = fixtureWithFormatVersion(formatVersion);
             var vaultEncryptedVariable = new VaultEncryptedVariable(encryptString);
 
-            assertThat(vaultEncryptedVariable.getFormat()).isEqualTo(format);
+            assertThat(vaultEncryptedVariable.getFormatVersion()).isEqualTo(formatVersion);
         }
 
         @ParameterizedTest
@@ -125,8 +125,8 @@ class VaultEncryptedVariableTest {
                 "1.1, AES256",
                 "1.2, AES256"
         })
-        void shouldParseCipher(String format, String expectedCipher) {
-            var encryptString = fixtureWithFormat(format);
+        void shouldParseCipher(String formatVersion, String expectedCipher) {
+            var encryptString = fixtureWithFormatVersion(formatVersion);
             var vaultEncryptedVariable = new VaultEncryptedVariable(encryptString);
 
             assertThat(vaultEncryptedVariable.getCipher()).isEqualTo(expectedCipher);
@@ -136,16 +136,16 @@ class VaultEncryptedVariableTest {
         class ShouldParseVaultIdLabel {
 
             @Test
-            void asEmpty_WhenFormat_1_1() {
-                var encryptString = fixtureWithFormat("1.1");
+            void asEmpty_WhenFormatVersion_1_1() {
+                var encryptString = fixtureWithFormatVersion("1.1");
                 var vaultEncryptedVariable = new VaultEncryptedVariable(encryptString);
 
                 assertThat(vaultEncryptedVariable.getVaultIdLabel()).isEmpty();
             }
 
             @Test
-            void whenFormat_1_2() {
-                var encryptString = fixtureWithFormat("1.2");
+            void whenFormatVersion_1_2() {
+                var encryptString = fixtureWithFormatVersion("1.2");
                 var vaultEncryptedVariable = new VaultEncryptedVariable(encryptString);
 
                 assertThat(vaultEncryptedVariable.getVaultIdLabel()).hasValue("dev");
@@ -154,19 +154,19 @@ class VaultEncryptedVariableTest {
 
         @ParameterizedTest
         @ValueSource(strings = {"1.1", "1.2"})
-        void shouldParseEncryptedContent(String format) {
-            var encryptString = fixtureWithFormat(format);
+        void shouldParseEncryptedContent(String formatVersion) {
+            var encryptString = fixtureWithFormatVersion(formatVersion);
             var vaultEncryptedVariable = new VaultEncryptedVariable(encryptString);
 
-            var encryptedContent = Fixtures.fixture("ansible-vault/encrypt_string_" + format + "_encrypted_content_only.txt")
+            var encryptedContent = Fixtures.fixture("ansible-vault/encrypt_string_" + formatVersion + "_encrypted_content_only.txt")
                     .lines()
                     .collect(toUnmodifiableList());
             assertThat(vaultEncryptedVariable.getEncryptedContentLines()).isEqualTo(encryptedContent);
         }
     }
 
-    private static String fixtureWithFormat(String format) {
-        return Fixtures.fixture("ansible-vault/encrypt_string_" + format + ".txt");
+    private static String fixtureWithFormatVersion(String version) {
+        return Fixtures.fixture("ansible-vault/encrypt_string_" + version + ".txt");
     }
 
     @Nested


### PR DESCRIPTION
* Rename format to formatVersion to be consistent with the
  ansible-vault documentation
* Rename private isValidFormat helper method to isValidFormatVersion
* Rename misc. stuff in VaultEncryptedVariableTest to use formatVersion