### PR TITLE
Add support for --vault-id option when encrypting files and strings

### DIFF
--- a/src/main/java/org/example/ansible/vault/VaultEncryptCommand.java
+++ b/src/main/java/org/example/ansible/vault/VaultEncryptCommand.java
@@ -1,5 +1,8 @@
 package org.example.ansible.vault;
 
+import static java.util.Objects.isNull;
+import static org.kiwiproject.base.KiwiStrings.f;
+
 import lombok.Builder;
 
 import java.util.List;
@@ -8,12 +11,20 @@ import java.util.List;
 public class VaultEncryptCommand implements OsCommand {
 
     private final String ansibleVaultPath;
+    private final String vaultIdLabel;
     private final String vaultPasswordFilePath;
     private final String plainTextFilePath;
 
     public static VaultEncryptCommand from(VaultConfiguration configuration, String plainTextFilePath) {
+        return from(configuration, null, plainTextFilePath);
+    }
+
+    public static VaultEncryptCommand from(VaultConfiguration configuration,
+                                           String vaultIdLabel,
+                                           String plainTextFilePath) {
         return VaultEncryptCommand.builder()
                 .ansibleVaultPath(configuration.getAnsibleVaultPath())
+                .vaultIdLabel(vaultIdLabel)
                 .vaultPasswordFilePath(configuration.getVaultPasswordFilePath())
                 .plainTextFilePath(plainTextFilePath)
                 .build();
@@ -21,11 +32,24 @@ public class VaultEncryptCommand implements OsCommand {
 
     @Override
     public List<String> getCommandParts() {
+        if (isNull(vaultIdLabel)) {
+            return List.of(
+                    ansibleVaultPath,
+                    "encrypt",
+                    "--vault-password-file", vaultPasswordFilePath,
+                    plainTextFilePath
+            );
+        }
+
         return List.of(
                 ansibleVaultPath,
                 "encrypt",
-                "--vault-password-file", vaultPasswordFilePath,
+                "--vault-id", vaultIdArgument(),
                 plainTextFilePath
         );
+    }
+
+    private String vaultIdArgument() {
+        return f("{}@{}", vaultIdLabel, vaultPasswordFilePath);
     }
 }

--- a/src/main/java/org/example/ansible/vault/VaultEncryptStringCommand.java
+++ b/src/main/java/org/example/ansible/vault/VaultEncryptStringCommand.java
@@ -1,5 +1,8 @@
 package org.example.ansible.vault;
 
+import static java.util.Objects.isNull;
+import static org.kiwiproject.base.KiwiStrings.f;
+
 import lombok.Builder;
 
 import java.util.List;
@@ -8,6 +11,7 @@ import java.util.List;
 public class VaultEncryptStringCommand implements OsCommand {
 
     private final String ansibleVaultPath;
+    private final String vaultIdLabel;
     private final String vaultPasswordFilePath;
     private final String variableName;
     private final String plainText;
@@ -15,8 +19,16 @@ public class VaultEncryptStringCommand implements OsCommand {
     public static VaultEncryptStringCommand from(VaultConfiguration configuration,
                                                  String plainText,
                                                  String variableName) {
+        return from(configuration, null, plainText, variableName);
+    }
+
+    public static VaultEncryptStringCommand from(VaultConfiguration configuration,
+                                                 String vaultIdLabel,
+                                                 String plainText,
+                                                 String variableName) {
         return VaultEncryptStringCommand.builder()
                 .ansibleVaultPath(configuration.getAnsibleVaultPath())
+                .vaultIdLabel(vaultIdLabel)
                 .vaultPasswordFilePath(configuration.getVaultPasswordFilePath())
                 .variableName(variableName)
                 .plainText(plainText)
@@ -25,12 +37,26 @@ public class VaultEncryptStringCommand implements OsCommand {
 
     @Override
     public List<String> getCommandParts() {
+        if (isNull(vaultIdLabel)) {
+            return List.of(
+                    ansibleVaultPath,
+                    "encrypt_string",
+                    "--vault-password-file", vaultPasswordFilePath,
+                    "--name", variableName,
+                    plainText
+            );
+        }
+
         return List.of(
                 ansibleVaultPath,
                 "encrypt_string",
-                "--vault-password-file", vaultPasswordFilePath,
+                "--vault-id", vaultIdArgument(),
                 "--name", variableName,
                 plainText
         );
+    }
+
+    private String vaultIdArgument() {
+        return f("{}@{}", vaultIdLabel, vaultPasswordFilePath);
     }
 }

--- a/src/main/java/org/example/ansible/vault/VaultEncryptionHelper.java
+++ b/src/main/java/org/example/ansible/vault/VaultEncryptionHelper.java
@@ -49,6 +49,15 @@ public class VaultEncryptionHelper {
     }
 
     /**
+     * Wraps the ansible-vault encrypt command using a vault ID label. Encrypts file in place.
+     */
+    public Path encryptFile(String plainTextFilePath, String vaultIdLabel, VaultConfiguration configuration) {
+        validateEncryptionConfiguration(configuration);
+        var osCommand = VaultEncryptCommand.from(configuration, vaultIdLabel, plainTextFilePath);
+        return executeVaultCommandWithoutOutput(osCommand, plainTextFilePath);
+    }
+
+    /**
      * Wraps ansible-vault decrypt command. Decrypts file in place.
      */
     public Path decryptFile(String encryptedFilePath, VaultConfiguration configuration) {
@@ -110,6 +119,18 @@ public class VaultEncryptionHelper {
     public String encryptString(String plainText, String variableName, VaultConfiguration configuration) {
         validateEncryptionConfiguration(configuration);
         var osCommand = VaultEncryptStringCommand.from(configuration, plainText, variableName);
+        return executeVaultCommandReturningStdout(osCommand);
+    }
+
+    /**
+     * Wraps the ansible-vault encrypt_string command  using a vault ID label.
+     */
+    public String encryptString(String vaultIdLabel,
+                                String plainText,
+                                String variableName,
+                                VaultConfiguration configuration) {
+        validateEncryptionConfiguration(configuration);
+        var osCommand = VaultEncryptStringCommand.from(configuration, vaultIdLabel, plainText, variableName);
         return executeVaultCommandReturningStdout(osCommand);
     }
 

--- a/src/test/java/org/example/ansible/vault/VaultEncryptCommandTest.java
+++ b/src/test/java/org/example/ansible/vault/VaultEncryptCommandTest.java
@@ -33,4 +33,20 @@ class VaultEncryptCommandTest {
                 plainTextFileName
         );
     }
+
+    @Test
+    void shouldBuildCommand_WithVaultId() {
+        var vaultIdLabel = "test";
+        var plainTextFileName = "/data/etc/secrets/passwords.txt";
+
+        var command = VaultEncryptCommand.from(configuration, vaultIdLabel, plainTextFileName);
+
+        assertThat(command.getCommandParts()).containsExactly(
+                configuration.getAnsibleVaultPath(),
+                "encrypt",
+                "--vault-id",
+                vaultIdLabel + "@" + configuration.getVaultPasswordFilePath(),
+                plainTextFileName
+        );
+    }
 }

--- a/src/test/java/org/example/ansible/vault/VaultEncryptStringCommandTest.java
+++ b/src/test/java/org/example/ansible/vault/VaultEncryptStringCommandTest.java
@@ -35,4 +35,22 @@ class VaultEncryptStringCommandTest {
                 plainText
         );
     }
+
+    @Test
+    void shouldBuildCommand_WithVaultId() {
+        var vaultIdLabel = "test";
+        var plainText = "the plain text";
+        var variableName = "MySecret";
+        var command = VaultEncryptStringCommand.from(configuration, vaultIdLabel, plainText, variableName);
+
+        assertThat(command.getCommandParts()).containsExactly(
+                configuration.getAnsibleVaultPath(),
+                "encrypt_string",
+                "--vault-id",
+                vaultIdLabel + "@" + configuration.getVaultPasswordFilePath(),
+                "--name",
+                variableName,
+                plainText
+        );
+    }
 }


### PR DESCRIPTION
* Modify VaultEncryptCommand and VaultEncryptStringCommand to accept
  a vaultIdLabel, which if present will cause the returned command
  to use --vault-id [label]@[password_file] instead of the
  --vault-password-file option
* Add overloaded versions of encryptFile and encryptString in
  VaultEncryptionHelper that accept a vaultIdLabel, which will cause
  the actual ansible-vault commands to use --vault-id as mentioned above

NOTE: Did not add any support for adding a vaultIdLabel on decrypt
or view, because (so far as I can tell and from trying out a bunch of
test cases on the command line), it does not actually matter and
you can always just use --vault-password-file to decrypt. Even more
oddly, the default behavior allows you to pass ANY label when decrypting
and it will still decrypt just fine assuming you supply the correct
password file. For example you could supply foo@~/.vault_pass or
bar~/.vault_pass or baz@~/.vault_pass and all will work no matter what
label it was encrypted with. I will freely admit that there must be
something I am missing, or some reason for this behavior.

Fixes #5