### PR TITLE
Add VaultConfiguration argument to ctors in VaultEncryptionHelper

### DIFF
--- a/src/main/java/org/example/ansible/vault/Main.java
+++ b/src/main/java/org/example/ansible/vault/Main.java
@@ -47,7 +47,7 @@ public class Main {
                 .tempDirectory(tempPath.toString())
                 .build();
 
-        var helper = new VaultEncryptionHelper();
+        var helper = new VaultEncryptionHelper(config);
 
         var decryptedValue = helper.decryptString(encryptedString, config);
         printDecryptedValue(decryptedValue);

--- a/src/main/java/org/example/ansible/vault/MainDecryptFile.java
+++ b/src/main/java/org/example/ansible/vault/MainDecryptFile.java
@@ -32,12 +32,12 @@ public class MainDecryptFile {
         var plainText = "some plain text" + System.lineSeparator();
         var textFile = Files.writeString(filePath, plainText);
 
-        var helper = new VaultEncryptionHelper();
-
         var config = VaultConfiguration.builder()
                 .ansibleVaultPath(ansibleVaultExecPath.toString())
                 .vaultPasswordFilePath(vaultPasswordPath.toString())
                 .build();
+
+        var helper = new VaultEncryptionHelper(config);
 
         var encryptedFile = helper.encryptFile(textFile.toString(), config);
 

--- a/src/main/java/org/example/ansible/vault/MainEncryptFile.java
+++ b/src/main/java/org/example/ansible/vault/MainEncryptFile.java
@@ -31,12 +31,12 @@ public class MainEncryptFile {
         var filePath = Path.of(tmpDir.toString(), "tmp" + System.nanoTime() + ".txt");
         var textFile = Files.writeString(filePath, "some plain text" + System.lineSeparator());
 
-        var helper = new VaultEncryptionHelper();
-
         var config = VaultConfiguration.builder()
                 .ansibleVaultPath(ansibleVaultExecPath.toString())
                 .vaultPasswordFilePath(vaultPasswordPath.toString())
                 .build();
+
+        var helper = new VaultEncryptionHelper(config);
 
         var encryptedFile = helper.encryptFile(textFile.toString(), config);
 

--- a/src/main/java/org/example/ansible/vault/VaultEncryptionHelper.java
+++ b/src/main/java/org/example/ansible/vault/VaultEncryptionHelper.java
@@ -20,7 +20,6 @@ import java.nio.file.Path;
 import java.util.concurrent.TimeUnit;
 
 @Slf4j
-@SuppressWarnings({"java:S125"})
 public class VaultEncryptionHelper {
 
     private static final String LINE_SEPARATOR = System.lineSeparator();
@@ -29,13 +28,15 @@ public class VaultEncryptionHelper {
     private static final TimeUnit DEFAULT_TIMEOUT_UNIT = TimeUnit.SECONDS;
 
     private final ProcessHelper processHelper;
+    private final VaultConfiguration configuration;
 
-    public VaultEncryptionHelper() {
-        this(new ProcessHelper());
+    public VaultEncryptionHelper(VaultConfiguration configuration) {
+        this(configuration, new ProcessHelper());
     }
 
     @VisibleForTesting
-    VaultEncryptionHelper(ProcessHelper processHelper) {
+    VaultEncryptionHelper(VaultConfiguration configuration, ProcessHelper processHelper) {
+        this.configuration = configuration;
         this.processHelper = processHelper;
     }
 

--- a/src/test/java/org/example/ansible/vault/VaultEncryptionHelperIntegrationTest.java
+++ b/src/test/java/org/example/ansible/vault/VaultEncryptionHelperIntegrationTest.java
@@ -71,7 +71,6 @@ class VaultEncryptionHelperIntegrationTest {
 
     @BeforeEach
     void setUp() throws IOException {
-        helper = new VaultEncryptionHelper();
         tempDir = tempDirPath.toString();
 
         var passwordFilePath = Path.of(tempDir, ".vault_pass");
@@ -82,6 +81,8 @@ class VaultEncryptionHelperIntegrationTest {
                 .vaultPasswordFilePath(passwordFilePath.toString())
                 .tempDirectory(tempDir)
                 .build();
+
+        helper = new VaultEncryptionHelper(config);
     }
 
     @Nested

--- a/src/test/java/org/example/ansible/vault/VaultEncryptionHelperTest.java
+++ b/src/test/java/org/example/ansible/vault/VaultEncryptionHelperTest.java
@@ -74,7 +74,7 @@ class VaultEncryptionHelperTest {
 
         processHelper = mock(ProcessHelper.class);
         process = mock(Process.class);
-        helper = new VaultEncryptionHelper(processHelper);
+        helper = new VaultEncryptionHelper(configuration, processHelper);
     }
 
     @Nested


### PR DESCRIPTION
This is the first part of changing VaultEncryptionHelper so that
the methods don't require passing a VaultConfiguration on every
invocation. (see issue forty six, which I am spelling out since I don't
want GitHub automatically closing it right now)