### PR TITLE
Remove redundant config argument from VaultEncryptionHelper methods

### DIFF
--- a/src/main/java/org/example/ansible/vault/Main.java
+++ b/src/main/java/org/example/ansible/vault/Main.java
@@ -49,7 +49,7 @@ public class Main {
 
         var helper = new VaultEncryptionHelper(config);
 
-        var decryptedValue = helper.decryptString(encryptedString, config);
+        var decryptedValue = helper.decryptString(encryptedString);
         printDecryptedValue(decryptedValue);
 
         // --- Do several encrypt/decrypt cycles ----
@@ -61,10 +61,10 @@ public class Main {
             System.out.printf(
                     "---------- Iteration %d -------------------------------------------------------------------%n%n", i);
 
-            var encryptedValue = helper.encryptString(plainText, variableName, config);
+            var encryptedValue = helper.encryptString(plainText, variableName);
             printEncryptedValue(encryptedValue);
 
-            var reDecryptedValue = helper.decryptString(encryptedValue, config);
+            var reDecryptedValue = helper.decryptString(encryptedValue);
             printDecryptedValue(reDecryptedValue);
 
             plainText = reDecryptedValue;

--- a/src/main/java/org/example/ansible/vault/MainDecryptFile.java
+++ b/src/main/java/org/example/ansible/vault/MainDecryptFile.java
@@ -39,11 +39,11 @@ public class MainDecryptFile {
 
         var helper = new VaultEncryptionHelper(config);
 
-        var encryptedFile = helper.encryptFile(textFile.toString(), config);
+        var encryptedFile = helper.encryptFile(textFile.toString());
 
         System.out.println("Encrypted file: " + encryptedFile);
 
-        var decryptedFile = helper.decryptFile(encryptedFile.toString(), config);
+        var decryptedFile = helper.decryptFile(encryptedFile.toString());
 
         System.out.println("Decrypted file: " + decryptedFile);
 

--- a/src/main/java/org/example/ansible/vault/MainEncryptFile.java
+++ b/src/main/java/org/example/ansible/vault/MainEncryptFile.java
@@ -38,7 +38,7 @@ public class MainEncryptFile {
 
         var helper = new VaultEncryptionHelper(config);
 
-        var encryptedFile = helper.encryptFile(textFile.toString(), config);
+        var encryptedFile = helper.encryptFile(textFile.toString());
 
         verify(encryptedFile.equals(textFile), "encryptedFile (%s) != textFile (%s)",
                 encryptedFile, textFile);
@@ -54,7 +54,7 @@ public class MainEncryptFile {
         System.out.println("Now cause failure by trying to encrypt the already-encrypted file...");
 
         try {
-            helper.encryptFile(encryptedFile.toString(), config);
+            helper.encryptFile(encryptedFile.toString());
         } catch (Exception e) {
             System.err.println("Error encrypting " + textFile);
             System.err.println(e.getClass());

--- a/src/main/java/org/example/ansible/vault/VaultConfiguration.java
+++ b/src/main/java/org/example/ansible/vault/VaultConfiguration.java
@@ -6,6 +6,9 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.Setter;
 
+/**
+ * This is mutable in case it is used in injected configuration, e.g. in a Dropwizard configuration file.
+ */
 @Getter
 @Setter
 public class VaultConfiguration {
@@ -27,5 +30,13 @@ public class VaultConfiguration {
 
     private String getJavaTempDir() {
         return System.getProperty("java.io.tmpdir");
+    }
+
+    public VaultConfiguration copyOf() {
+        return VaultConfiguration.builder()
+                .ansibleVaultPath(ansibleVaultPath)
+                .vaultPasswordFilePath(vaultPasswordFilePath)
+                .tempDirectory(tempDirectory)
+                .build();
     }
 }

--- a/src/test/java/org/example/ansible/vault/VaultConfigurationTest.java
+++ b/src/test/java/org/example/ansible/vault/VaultConfigurationTest.java
@@ -43,7 +43,24 @@ class VaultConfigurationTest {
 
             assertTempDirectoryIsJavaTempDir(config);
         }
+    }
 
+    @Nested
+    class Copy {
+
+        @Test
+        void shouldCreateCopy() {
+            var original = VaultConfiguration.builder()
+                    .ansibleVaultPath("/usr/bin/ansible-vault")
+                    .vaultPasswordFilePath("/data/vault/.vault_pass")
+                    .build();
+
+            var copy = original.copyOf();
+
+            assertThat(copy)
+                    .isNotSameAs(original)
+                    .isEqualToComparingFieldByField(original);
+        }
     }
 
     private void assertTempDirectoryIsJavaTempDir(VaultConfiguration config) {

--- a/src/test/java/org/example/ansible/vault/VaultEncryptionHelperIntegrationTest.java
+++ b/src/test/java/org/example/ansible/vault/VaultEncryptionHelperIntegrationTest.java
@@ -47,7 +47,6 @@ class VaultEncryptionHelperIntegrationTest {
     private static String ansibleVaultFile;
 
     private VaultEncryptionHelper helper;
-    private VaultConfiguration config;
 
     @TempDir
     Path tempDirPath;
@@ -76,7 +75,7 @@ class VaultEncryptionHelperIntegrationTest {
         var passwordFilePath = Path.of(tempDir, ".vault_pass");
         Files.writeString(passwordFilePath, PASSWORD);
 
-        config = VaultConfiguration.builder()
+        var config = VaultConfiguration.builder()
                 .ansibleVaultPath(ansibleVaultFile)
                 .vaultPasswordFilePath(passwordFilePath.toString())
                 .tempDirectory(tempDir)
@@ -97,7 +96,7 @@ class VaultEncryptionHelperIntegrationTest {
 
         @Test
         void shouldEncryptPlainTextFile() {
-            var encryptedFile = helper.encryptFile(plainTextFile.toString(), config);
+            var encryptedFile = helper.encryptFile(plainTextFile.toString());
 
             assertThat(encryptedFile)
                     .describedAs("Encrypted file path should be the same")
@@ -106,16 +105,16 @@ class VaultEncryptionHelperIntegrationTest {
 
         @Test
         void shouldThrowWhenGivenAlreadyEncryptedFile() {
-            var encryptedFile = helper.encryptFile(plainTextFile.toString(), config).toString();
+            var encryptedFile = helper.encryptFile(plainTextFile.toString()).toString();
 
-            assertThatThrownBy(() -> helper.encryptFile(encryptedFile, config))
+            assertThatThrownBy(() -> helper.encryptFile(encryptedFile))
                     .isExactlyInstanceOf(VaultEncryptionException.class)
                     .hasMessageStartingWith("ansible-vault returned non-zero exit code 1. Stderr: ");
         }
 
         @Test
         void shouldThrowWhenGivenFileThatDoesNotExist() {
-            assertThatThrownBy(() -> helper.encryptFile("/does/not/exist.txt", config))
+            assertThatThrownBy(() -> helper.encryptFile("/does/not/exist.txt"))
                     .isExactlyInstanceOf(VaultEncryptionException.class)
                     .hasMessageStartingWith("ansible-vault returned non-zero exit code 1. Stderr: ");
         }
@@ -135,7 +134,7 @@ class VaultEncryptionHelperIntegrationTest {
 
         @Test
         void shouldEncryptPlainTextFile() throws IOException {
-            var encryptedFile = helper.encryptFile(plainTextFile.toString(), vaultIdLabel, config);
+            var encryptedFile = helper.encryptFile(plainTextFile.toString(), vaultIdLabel);
 
             assertThat(encryptedFile)
                     .describedAs("Encrypted file path should be the same")
@@ -147,16 +146,16 @@ class VaultEncryptionHelperIntegrationTest {
 
         @Test
         void shouldThrowWhenGivenAlreadyEncryptedFile() {
-            var encryptedFile = helper.encryptFile(plainTextFile.toString(), config).toString();
+            var encryptedFile = helper.encryptFile(plainTextFile.toString()).toString();
 
-            assertThatThrownBy(() -> helper.encryptFile(encryptedFile, vaultIdLabel, config))
+            assertThatThrownBy(() -> helper.encryptFile(encryptedFile, vaultIdLabel))
                     .isExactlyInstanceOf(VaultEncryptionException.class)
                     .hasMessageStartingWith("ansible-vault returned non-zero exit code 1. Stderr: ");
         }
 
         @Test
         void shouldThrowWhenGivenFileThatDoesNotExist() {
-            assertThatThrownBy(() -> helper.encryptFile("/does/not/exist.txt", vaultIdLabel, config))
+            assertThatThrownBy(() -> helper.encryptFile("/does/not/exist.txt", vaultIdLabel))
                     .isExactlyInstanceOf(VaultEncryptionException.class)
                     .hasMessageStartingWith("ansible-vault returned non-zero exit code 1. Stderr: ");
         }
@@ -178,7 +177,7 @@ class VaultEncryptionHelperIntegrationTest {
 
             @Test
             void shouldDecryptAnEncryptedFileInPlace() throws IOException {
-                var decryptedFile = helper.decryptFile(encryptedFile.toString(), config);
+                var decryptedFile = helper.decryptFile(encryptedFile.toString());
 
                 assertThat(decryptedFile)
                         .describedAs("Decrypted file path should be the same")
@@ -194,14 +193,14 @@ class VaultEncryptionHelperIntegrationTest {
                 var plainTextFile = Files.writeString(Path.of(tempDir, "foo.txt"), "some plain text")
                         .toString();
 
-                assertThatThrownBy(() -> helper.decryptFile(plainTextFile, config))
+                assertThatThrownBy(() -> helper.decryptFile(plainTextFile))
                         .isExactlyInstanceOf(VaultEncryptionException.class)
                         .hasMessageStartingWith("ansible-vault returned non-zero exit code 1. Stderr: ");
             }
 
             @Test
             void shouldThrowWhenGivenFileThatDoesNotExist() {
-                assertThatThrownBy(() -> helper.decryptFile("/does/not/exist.txt", config))
+                assertThatThrownBy(() -> helper.decryptFile("/does/not/exist.txt"))
                         .isExactlyInstanceOf(VaultEncryptionException.class)
                         .hasMessageStartingWith("ansible-vault returned non-zero exit code 1. Stderr: ");
             }
@@ -221,7 +220,7 @@ class VaultEncryptionHelperIntegrationTest {
 
             @Test
             void shouldDecryptAnEncryptedFileInPlace() throws IOException {
-                var decryptedFile = helper.decryptFile(encryptedFile.toString(), outputFile, config);
+                var decryptedFile = helper.decryptFile(encryptedFile.toString(), outputFile);
 
                 assertThat(decryptedFile)
                         .describedAs("Decrypted file path should be the same")
@@ -237,14 +236,14 @@ class VaultEncryptionHelperIntegrationTest {
                 var plainTextFile = Files.writeString(Path.of(tempDir, "foo.txt"), "some plain text")
                         .toString();
 
-                assertThatThrownBy(() -> helper.decryptFile(plainTextFile, outputFile, config))
+                assertThatThrownBy(() -> helper.decryptFile(plainTextFile, outputFile))
                         .isExactlyInstanceOf(VaultEncryptionException.class)
                         .hasMessageStartingWith("ansible-vault returned non-zero exit code 1. Stderr: ");
             }
 
             @Test
             void shouldThrowWhenGivenFileThatDoesNotExist() {
-                assertThatThrownBy(() -> helper.decryptFile("/does/not/exist.txt", outputFile, config))
+                assertThatThrownBy(() -> helper.decryptFile("/does/not/exist.txt", outputFile))
                         .isExactlyInstanceOf(VaultEncryptionException.class)
                         .hasMessageStartingWith("ansible-vault returned non-zero exit code 1. Stderr: ");
             }
@@ -264,7 +263,7 @@ class VaultEncryptionHelperIntegrationTest {
 
         @Test
         void shouldViewEncryptedFile() {
-            var plainText = helper.viewFile(encryptedFile.toString(), config);
+            var plainText = helper.viewFile(encryptedFile.toString());
 
             assertThat(plainText).isEqualToNormalizingWhitespace(THE_SECRET);
         }
@@ -273,7 +272,7 @@ class VaultEncryptionHelperIntegrationTest {
         void shouldNotChangeEncryptedFile() throws IOException {
             var originalEncryptedContent = Files.readString(encryptedFile, StandardCharsets.UTF_8);
 
-            helper.viewFile(encryptedFile.toString(), config);
+            helper.viewFile(encryptedFile.toString());
 
             assertThat(encryptedFile).hasContent(originalEncryptedContent);
         }
@@ -283,14 +282,14 @@ class VaultEncryptionHelperIntegrationTest {
             var plainTextFile = Files.writeString(Path.of(tempDir, "foo.txt"), "some plain text")
                     .toString();
 
-            assertThatThrownBy(() -> helper.viewFile(plainTextFile, config))
+            assertThatThrownBy(() -> helper.viewFile(plainTextFile))
                     .isExactlyInstanceOf(VaultEncryptionException.class)
                     .hasMessageStartingWith("ansible-vault returned non-zero exit code 1. Stderr: ");
         }
 
         @Test
         void shouldThrowWhenGivenFileThatDoesNotExist() {
-            assertThatThrownBy(() -> helper.viewFile("/does/not/exist.txt", config))
+            assertThatThrownBy(() -> helper.viewFile("/does/not/exist.txt"))
                     .isExactlyInstanceOf(VaultEncryptionException.class)
                     .hasMessageStartingWith("ansible-vault returned non-zero exit code 1. Stderr: ");
         }
@@ -321,16 +320,17 @@ class VaultEncryptionHelperIntegrationTest {
 
         @Test
         void shouldRekeyAnEncryptedFile() {
-            var rekeyedFile = helper.rekeyFile(encryptedFile.toString(), newPasswordFile.toString(), config);
-
+            var rekeyedFile = helper.rekeyFile(encryptedFile.toString(), newPasswordFile.toString());
             var rekeyedFilePath = rekeyedFile.toString();
-            var fileContent = helper.viewFile(rekeyedFilePath, newConfig);
-            assertThat(fileContent).isEqualToNormalizingWhitespace(THE_SECRET);
 
-            assertThatThrownBy(() -> helper.viewFile(rekeyedFilePath, config))
+            assertThatThrownBy(() -> helper.viewFile(rekeyedFilePath))
                     .describedAs("Should not be able to decrypt using original password file")
                     .isExactlyInstanceOf(VaultEncryptionException.class)
                     .hasMessageStartingWith("ansible-vault returned non-zero exit code 1. Stderr: ");
+
+            var newHelper = new VaultEncryptionHelper(newConfig);
+            var fileContent = newHelper.viewFile(rekeyedFilePath);
+            assertThat(fileContent).isEqualToNormalizingWhitespace(THE_SECRET);
         }
 
         @Test
@@ -339,7 +339,7 @@ class VaultEncryptionHelperIntegrationTest {
                     .toString();
             var newPasswordFilePath = newPasswordFile.toString();
 
-            assertThatThrownBy(() -> helper.rekeyFile(plainTextFile, newPasswordFilePath, config))
+            assertThatThrownBy(() -> helper.rekeyFile(plainTextFile, newPasswordFilePath))
                     .isExactlyInstanceOf(VaultEncryptionException.class)
                     .hasMessageStartingWith("ansible-vault returned non-zero exit code 1. Stderr: ");
         }
@@ -348,7 +348,7 @@ class VaultEncryptionHelperIntegrationTest {
         void shouldThrowWhenGivenFileThatDoesNotExist() {
             var newPasswordFilePath = newPasswordFile.toString();
 
-            assertThatThrownBy(() -> helper.rekeyFile("/does/not/exist.txt", newPasswordFilePath, config))
+            assertThatThrownBy(() -> helper.rekeyFile("/does/not/exist.txt", newPasswordFilePath))
                     .isExactlyInstanceOf(VaultEncryptionException.class)
                     .hasMessageStartingWith("ansible-vault returned non-zero exit code");
         }
@@ -364,7 +364,7 @@ class VaultEncryptionHelperIntegrationTest {
                 "some_variable,67890-12345"
         })
         void shouldEncryptStringInValidFormat(String variableName, String plainText) {
-            var encryptedString = helper.encryptString(plainText, variableName, config);
+            var encryptedString = helper.encryptString(plainText, variableName);
             var variable = new VaultEncryptedVariable(encryptedString);
 
             assertThat(variable.getVariableName()).isEqualTo(variableName);
@@ -378,8 +378,8 @@ class VaultEncryptionHelperIntegrationTest {
                 "another_variable,12345"
         })
         void shouldEncryptAndDecryptStrings(String variableName, String plainText) {
-            var encryptedString = helper.encryptString(plainText, variableName, config);
-            var decryptedString = helper.decryptString(encryptedString, config);
+            var encryptedString = helper.encryptString(plainText, variableName);
+            var decryptedString = helper.decryptString(encryptedString);
 
             assertThat(decryptedString).isEqualTo(plainText);
         }
@@ -402,7 +402,7 @@ class VaultEncryptionHelperIntegrationTest {
                 "some_variable,67890-12345"
         })
         void shouldEncryptStringInValidFormat(String variableName, String plainText) {
-            var encryptedString = helper.encryptString(vaultIdLabel, plainText, variableName, config);
+            var encryptedString = helper.encryptString(vaultIdLabel, plainText, variableName);
             var variable = new VaultEncryptedVariable(encryptedString);
 
             assertThat(variable.getVariableName()).isEqualTo(variableName);
@@ -416,13 +416,13 @@ class VaultEncryptionHelperIntegrationTest {
                 "another_variable,12345"
         })
         void shouldEncryptAndDecryptStrings(String variableName, String plainText) {
-            var encryptedString = helper.encryptString(vaultIdLabel, plainText, variableName, config);
+            var encryptedString = helper.encryptString(vaultIdLabel, plainText, variableName);
             var variable = new VaultEncryptedVariable(encryptedString);
 
             assertThat(variable.getVariableName()).isEqualTo(variableName);
             assertThat(variable.getVaultIdLabel()).hasValue(vaultIdLabel);
 
-            var decryptedString = helper.decryptString(encryptedString, config);
+            var decryptedString = helper.decryptString(encryptedString);
 
             assertThat(decryptedString).isEqualTo(plainText);
         }

--- a/src/test/java/org/example/ansible/vault/VaultEncryptionHelperTest.java
+++ b/src/test/java/org/example/ansible/vault/VaultEncryptionHelperTest.java
@@ -104,7 +104,7 @@ class VaultEncryptionHelperTest {
 
             var plainTextFile = "/data/etc/secrets.yml";
 
-            var encryptedFile = helper.encryptFile(plainTextFile, configuration);
+            var encryptedFile = helper.encryptFile(plainTextFile);
 
             assertThat(encryptedFile).isEqualTo(Path.of(plainTextFile));
 
@@ -119,7 +119,7 @@ class VaultEncryptionHelperTest {
 
             var plainTextFile = "/data/etc/secrets.yml";
 
-            assertThatThrownBy(() -> helper.encryptFile(plainTextFile, configuration))
+            assertThatThrownBy(() -> helper.encryptFile(plainTextFile))
                     .isExactlyInstanceOf(VaultEncryptionException.class)
                     .hasMessage("ansible-vault returned non-zero exit code 1. Stderr: %s", errorOutput);
 
@@ -138,7 +138,7 @@ class VaultEncryptionHelperTest {
             var vaultIdLabel = "prod";
             var plainTextFile = "/data/etc/prod-secrets.yml";
 
-            var encryptedFile = helper.encryptFile(plainTextFile, vaultIdLabel, configuration);
+            var encryptedFile = helper.encryptFile(plainTextFile, vaultIdLabel);
 
             assertThat(encryptedFile).isEqualTo(Path.of(plainTextFile));
 
@@ -154,7 +154,7 @@ class VaultEncryptionHelperTest {
             var vaultIdLabel = "staging";
             var plainTextFile = "/data/etc/staging-secrets.yml";
 
-            assertThatThrownBy(() -> helper.encryptFile(plainTextFile, vaultIdLabel, configuration))
+            assertThatThrownBy(() -> helper.encryptFile(plainTextFile, vaultIdLabel))
                     .isExactlyInstanceOf(VaultEncryptionException.class)
                     .hasMessage("ansible-vault returned non-zero exit code 1. Stderr: %s", errorOutput);
 
@@ -175,7 +175,7 @@ class VaultEncryptionHelperTest {
 
                 var encryptedFile = "/data/etc/secrets.yml";
 
-                var decryptedFile = helper.decryptFile(encryptedFile, configuration);
+                var decryptedFile = helper.decryptFile(encryptedFile);
 
                 assertThat(decryptedFile).isEqualTo(Path.of(encryptedFile));
 
@@ -190,7 +190,7 @@ class VaultEncryptionHelperTest {
 
                 var encryptedFilePath = "/etc/secrets.yml";
 
-                assertThatThrownBy(() -> helper.decryptFile(encryptedFilePath, configuration))
+                assertThatThrownBy(() -> helper.decryptFile(encryptedFilePath))
                         .isExactlyInstanceOf(VaultEncryptionException.class)
                         .hasMessage("ansible-vault returned non-zero exit code 1. Stderr: %s", errorOutput);
 
@@ -209,7 +209,7 @@ class VaultEncryptionHelperTest {
                 var encryptedFile = "/data/crypt/secrets.yml";
                 var outputFile = "/data/var/secrets.yml";
 
-                var decryptedFile = helper.decryptFile(encryptedFile, outputFile, configuration);
+                var decryptedFile = helper.decryptFile(encryptedFile, outputFile);
 
                 assertThat(decryptedFile).isEqualTo(Path.of(outputFile));
 
@@ -225,7 +225,7 @@ class VaultEncryptionHelperTest {
             })
             void shouldNotPermitNewFileLocationToOverwriteEncryptedFile(String encryptedFile, String outputFile) {
                 assertThatIllegalArgumentException()
-                        .isThrownBy(() -> helper.decryptFile(encryptedFile, outputFile, configuration))
+                        .isThrownBy(() -> helper.decryptFile(encryptedFile, outputFile))
                         .withMessage("outputFilePath must be different than encryptedFilePath (case-insensitive)");
 
                 verifyNoInteractions(processHelper);
@@ -239,7 +239,7 @@ class VaultEncryptionHelperTest {
                 var encryptedFile = "/data/crypt/secrets.yml";
                 var outputFile = "/data/var/secrets.yml";
 
-                assertThatThrownBy(() -> helper.decryptFile(encryptedFile, outputFile, configuration))
+                assertThatThrownBy(() -> helper.decryptFile(encryptedFile, outputFile))
                         .isExactlyInstanceOf(VaultEncryptionException.class)
                         .hasMessage("ansible-vault returned non-zero exit code 1. Stderr: %s", errorOutput);
 
@@ -259,7 +259,7 @@ class VaultEncryptionHelperTest {
 
             var encryptedFile = "/data/etc/secrets.yml";
 
-            var decryptedContents = helper.viewFile(encryptedFile, configuration);
+            var decryptedContents = helper.viewFile(encryptedFile);
 
             assertThat(decryptedContents).isEqualTo(plainText);
 
@@ -274,7 +274,7 @@ class VaultEncryptionHelperTest {
 
             var encryptedFilePath = "/etc/secrets.yml";
 
-            assertThatThrownBy(() -> helper.viewFile(encryptedFilePath, configuration))
+            assertThatThrownBy(() -> helper.viewFile(encryptedFilePath))
                     .isExactlyInstanceOf(VaultEncryptionException.class)
                     .hasMessage("ansible-vault returned non-zero exit code 1. Stderr: %s", errorOutput);
 
@@ -293,7 +293,7 @@ class VaultEncryptionHelperTest {
             var encryptedFile = "/data/etc/secrets.yml";
             var newVaultPasswordFilePath = "~/.new_vault_pass.txt";
 
-            var rekeyedFile = helper.rekeyFile(encryptedFile, newVaultPasswordFilePath, configuration);
+            var rekeyedFile = helper.rekeyFile(encryptedFile, newVaultPasswordFilePath);
 
             assertThat(rekeyedFile).isEqualTo(Path.of(encryptedFile));
 
@@ -307,7 +307,7 @@ class VaultEncryptionHelperTest {
             var newVaultPasswordFilePath = configuration.getVaultPasswordFilePath();
 
             assertThatIllegalArgumentException()
-                    .isThrownBy(() -> helper.rekeyFile(encryptedFile, newVaultPasswordFilePath, configuration))
+                    .isThrownBy(() -> helper.rekeyFile(encryptedFile, newVaultPasswordFilePath))
                     .withMessage("newVaultPasswordFilePath file must be different than configuration.vaultPasswordFilePath (case-insensitive)");
 
             verifyNoInteractions(processHelper);
@@ -321,7 +321,7 @@ class VaultEncryptionHelperTest {
             var encryptedFilePath = "/etc/secrets.yml";
             var newVaultPasswordFilePath = "~/.new_vault_pass.txt";
 
-            assertThatThrownBy(() -> helper.rekeyFile(encryptedFilePath, newVaultPasswordFilePath, configuration))
+            assertThatThrownBy(() -> helper.rekeyFile(encryptedFilePath, newVaultPasswordFilePath))
                     .isExactlyInstanceOf(VaultEncryptionException.class)
                     .hasMessage("ansible-vault returned non-zero exit code 1. Stderr: %s", errorOutput);
 
@@ -341,7 +341,7 @@ class VaultEncryptionHelperTest {
 
             var plainText = "this is the plain text";
             var variableName = "some_variable";
-            var result = helper.encryptString(plainText, variableName, configuration);
+            var result = helper.encryptString(plainText, variableName);
 
             assertThat(result).isEqualTo(encryptedContent);
 
@@ -357,7 +357,7 @@ class VaultEncryptionHelperTest {
             var plainText = "my-password";
             var variableName = "db_password";
             assertThatThrownBy(() ->
-                    helper.encryptString(plainText, variableName, configuration))
+                    helper.encryptString(plainText, variableName))
                     .isExactlyInstanceOf(VaultEncryptionException.class)
                     .hasMessage("ansible-vault returned non-zero exit code 1. Stderr: %s", errorOutput);
 
@@ -378,7 +378,7 @@ class VaultEncryptionHelperTest {
             var vaultIdLabel = "dev";
             var plainText = "this is the plain text";
             var variableName = "some_variable";
-            var result = helper.encryptString(vaultIdLabel, plainText, variableName, configuration);
+            var result = helper.encryptString(vaultIdLabel, plainText, variableName);
 
             assertThat(result).isEqualTo(encryptedContent);
 
@@ -395,7 +395,7 @@ class VaultEncryptionHelperTest {
             var plainText = "my-password";
             var variableName = "db_password";
             assertThatThrownBy(() ->
-                    helper.encryptString(vaultIdLabel, plainText, variableName, configuration))
+                    helper.encryptString(vaultIdLabel, plainText, variableName))
                     .isExactlyInstanceOf(VaultEncryptionException.class)
                     .hasMessage("ansible-vault returned non-zero exit code 1. Stderr: %s", errorOutput);
 
@@ -414,7 +414,7 @@ class VaultEncryptionHelperTest {
 
             var encryptedString = Fixtures.fixture(ENCRYPT_STRING_1_1_FORMAT);
 
-            var result = helper.decryptString(encryptedString, configuration);
+            var result = helper.decryptString(encryptedString);
 
             assertThat(result).isEqualTo(plainText);
 
@@ -458,7 +458,7 @@ class VaultEncryptionHelperTest {
 
             var encryptedString = Fixtures.fixture(ENCRYPT_STRING_1_1_FORMAT);
 
-            assertThatThrownBy(() -> helper.decryptString(encryptedString, configuration))
+            assertThatThrownBy(() -> helper.decryptString(encryptedString))
                     .isExactlyInstanceOf(VaultEncryptionException.class)
                     .hasMessage("ansible-vault returned non-zero exit code 1. Stderr: %s", errorOutput);
 


### PR DESCRIPTION
* Make defensive copy of the mutable VaultConfiguration in the
  VaultEncryptionHelper constructor before assigning it
* Remove VaultConfiguration argument from all public methods in
  VaultEncryptionHelper, now that the config must be specified in
  the constructor
* Remove validation of configuration in all VaultEncryptionHelper
  public methods, again since it is required and validated in the
  constructor now.