### PR TITLE
Add method overloads in VaultEncryptionHelper that accept Path

### DIFF
--- a/src/main/java/org/example/ansible/vault/MainDecryptFile.java
+++ b/src/main/java/org/example/ansible/vault/MainDecryptFile.java
@@ -39,11 +39,11 @@ public class MainDecryptFile {
 
         var helper = new VaultEncryptionHelper(config);
 
-        var encryptedFile = helper.encryptFile(textFile.toString());
+        var encryptedFile = helper.encryptFile(textFile);
 
         System.out.println("Encrypted file: " + encryptedFile);
 
-        var decryptedFile = helper.decryptFile(encryptedFile.toString());
+        var decryptedFile = helper.decryptFile(encryptedFile);
 
         System.out.println("Decrypted file: " + decryptedFile);
 

--- a/src/main/java/org/example/ansible/vault/MainEncryptFile.java
+++ b/src/main/java/org/example/ansible/vault/MainEncryptFile.java
@@ -38,7 +38,7 @@ public class MainEncryptFile {
 
         var helper = new VaultEncryptionHelper(config);
 
-        var encryptedFile = helper.encryptFile(textFile.toString());
+        var encryptedFile = helper.encryptFile(textFile);
 
         verify(encryptedFile.equals(textFile), "encryptedFile (%s) != textFile (%s)",
                 encryptedFile, textFile);
@@ -54,7 +54,7 @@ public class MainEncryptFile {
         System.out.println("Now cause failure by trying to encrypt the already-encrypted file...");
 
         try {
-            helper.encryptFile(encryptedFile.toString());
+            helper.encryptFile(encryptedFile);
         } catch (Exception e) {
             System.err.println("Error encrypting " + textFile);
             System.err.println(e.getClass());

--- a/src/main/java/org/example/ansible/vault/VaultEncryptionHelper.java
+++ b/src/main/java/org/example/ansible/vault/VaultEncryptionHelper.java
@@ -61,9 +61,23 @@ public class VaultEncryptionHelper {
     /**
      * Wraps the ansible-vault encrypt command. Encrypts file in place.
      */
+    public Path encryptFile(Path plainTextFilePath) {
+        return encryptFile(plainTextFilePath.toString());
+    }
+
+    /**
+     * Wraps the ansible-vault encrypt command. Encrypts file in place.
+     */
     public Path encryptFile(String plainTextFilePath) {
         var osCommand = VaultEncryptCommand.from(configuration, plainTextFilePath);
         return executeVaultCommandWithoutOutput(osCommand, plainTextFilePath);
+    }
+
+    /**
+     * Wraps the ansible-vault encrypt command using a vault ID label. Encrypts file in place.
+     */
+    public Path encryptFile(Path plainTextFilePath, String vaultIdLabel) {
+        return encryptFile(plainTextFilePath.toString(), vaultIdLabel);
     }
 
     /**
@@ -77,9 +91,24 @@ public class VaultEncryptionHelper {
     /**
      * Wraps ansible-vault decrypt command. Decrypts file in place.
      */
+    public Path decryptFile(Path encryptedFilePath) {
+        return decryptFile(encryptedFilePath.toString());
+    }
+
+    /**
+     * Wraps ansible-vault decrypt command. Decrypts file in place.
+     */
     public Path decryptFile(String encryptedFilePath) {
         var osCommand = VaultDecryptCommand.from(configuration, encryptedFilePath);
         return executeVaultCommandWithoutOutput(osCommand, encryptedFilePath);
+    }
+
+    /**
+     * Wraps ansible-vault decrypt command. Decrypts file to a new specified output path.
+     * The original encrypted file is not modified.
+     */
+    public Path decryptFile(Path encryptedFilePath, Path outputFilePath) {
+        return decryptFile(encryptedFilePath.toString(), outputFilePath.toString());
     }
 
     /**
@@ -100,11 +129,25 @@ public class VaultEncryptionHelper {
      * Wraps ansible-vault view command. Returns the decrypted contents of the file.
      * The original encrypted file is not modified.
      */
+    public String viewFile(Path encryptedFilePath) {
+        return viewFile(encryptedFilePath.toString());
+    }
+
+    /**
+     * Wraps ansible-vault view command. Returns the decrypted contents of the file.
+     * The original encrypted file is not modified.
+     */
     public String viewFile(String encryptedFilePath) {
         var osCommand = VaultViewCommand.from(configuration, encryptedFilePath);
         return executeVaultCommandReturningStdout(osCommand);
     }
 
+    /**
+     * Wraps ansible-vault rekey command. Returns the path of the rekeyed file.
+     */
+    public Path rekeyFile(Path encryptedFilePath, Path newVaultPasswordFilePath) {
+        return rekeyFile(encryptedFilePath.toString(), newVaultPasswordFilePath.toString());
+    }
 
     /**
      * Wraps ansible-vault rekey command. Returns the path of the rekeyed file.

--- a/src/test/java/org/example/ansible/vault/VaultEncryptionHelperIntegrationTest.java
+++ b/src/test/java/org/example/ansible/vault/VaultEncryptionHelperIntegrationTest.java
@@ -96,7 +96,7 @@ class VaultEncryptionHelperIntegrationTest {
 
         @Test
         void shouldEncryptPlainTextFile() {
-            var encryptedFile = helper.encryptFile(plainTextFile.toString());
+            var encryptedFile = helper.encryptFile(plainTextFile);
 
             assertThat(encryptedFile)
                     .describedAs("Encrypted file path should be the same")
@@ -105,7 +105,7 @@ class VaultEncryptionHelperIntegrationTest {
 
         @Test
         void shouldThrowWhenGivenAlreadyEncryptedFile() {
-            var encryptedFile = helper.encryptFile(plainTextFile.toString()).toString();
+            var encryptedFile = helper.encryptFile(plainTextFile);
 
             assertThatThrownBy(() -> helper.encryptFile(encryptedFile))
                     .isExactlyInstanceOf(VaultEncryptionException.class)
@@ -134,7 +134,7 @@ class VaultEncryptionHelperIntegrationTest {
 
         @Test
         void shouldEncryptPlainTextFile() throws IOException {
-            var encryptedFile = helper.encryptFile(plainTextFile.toString(), vaultIdLabel);
+            var encryptedFile = helper.encryptFile(plainTextFile, vaultIdLabel);
 
             assertThat(encryptedFile)
                     .describedAs("Encrypted file path should be the same")
@@ -146,7 +146,7 @@ class VaultEncryptionHelperIntegrationTest {
 
         @Test
         void shouldThrowWhenGivenAlreadyEncryptedFile() {
-            var encryptedFile = helper.encryptFile(plainTextFile.toString()).toString();
+            var encryptedFile = helper.encryptFile(plainTextFile);
 
             assertThatThrownBy(() -> helper.encryptFile(encryptedFile, vaultIdLabel))
                     .isExactlyInstanceOf(VaultEncryptionException.class)
@@ -177,7 +177,7 @@ class VaultEncryptionHelperIntegrationTest {
 
             @Test
             void shouldDecryptAnEncryptedFileInPlace() throws IOException {
-                var decryptedFile = helper.decryptFile(encryptedFile.toString());
+                var decryptedFile = helper.decryptFile(encryptedFile);
 
                 assertThat(decryptedFile)
                         .describedAs("Decrypted file path should be the same")
@@ -190,8 +190,7 @@ class VaultEncryptionHelperIntegrationTest {
 
             @Test
             void shouldThrowWhenGivenAnUnencryptedFile() throws IOException {
-                var plainTextFile = Files.writeString(Path.of(tempDir, "foo.txt"), "some plain text")
-                        .toString();
+                var plainTextFile = Files.writeString(Path.of(tempDir, "foo.txt"), "some plain text");
 
                 assertThatThrownBy(() -> helper.decryptFile(plainTextFile))
                         .isExactlyInstanceOf(VaultEncryptionException.class)
@@ -209,32 +208,29 @@ class VaultEncryptionHelperIntegrationTest {
         @Nested
         class ToNewFile {
 
-            private Path outputFilePath;
-            private String outputFile;
+            private Path outputFile;
 
             @BeforeEach
             void setUp() {
-                outputFilePath = Path.of(tempDir, "new.txt");
-                outputFile = outputFilePath.toString();
+                outputFile = Path.of(tempDir, "new.txt");
             }
 
             @Test
             void shouldDecryptAnEncryptedFileInPlace() throws IOException {
-                var decryptedFile = helper.decryptFile(encryptedFile.toString(), outputFile);
+                var decryptedFile = helper.decryptFile(encryptedFile, outputFile);
 
                 assertThat(decryptedFile)
                         .describedAs("Decrypted file path should be the same")
-                        .isEqualTo(outputFilePath);
+                        .isEqualTo(outputFile);
 
-                var decryptedContents = Files.readString(outputFilePath, StandardCharsets.UTF_8);
+                var decryptedContents = Files.readString(outputFile, StandardCharsets.UTF_8);
 
                 assertThat(decryptedContents).isEqualToNormalizingWhitespace(THE_SECRET);
             }
 
             @Test
             void shouldThrowWhenGivenAnUnencryptedFile() throws IOException {
-                var plainTextFile = Files.writeString(Path.of(tempDir, "foo.txt"), "some plain text")
-                        .toString();
+                var plainTextFile = Files.writeString(Path.of(tempDir, "foo.txt"), "some plain text");
 
                 assertThatThrownBy(() -> helper.decryptFile(plainTextFile, outputFile))
                         .isExactlyInstanceOf(VaultEncryptionException.class)
@@ -243,7 +239,9 @@ class VaultEncryptionHelperIntegrationTest {
 
             @Test
             void shouldThrowWhenGivenFileThatDoesNotExist() {
-                assertThatThrownBy(() -> helper.decryptFile("/does/not/exist.txt", outputFile))
+                var encryptedFile = Path.of("/does/not/exist.txt");
+
+                assertThatThrownBy(() -> helper.decryptFile(encryptedFile, outputFile))
                         .isExactlyInstanceOf(VaultEncryptionException.class)
                         .hasMessageStartingWith("ansible-vault returned non-zero exit code 1. Stderr: ");
             }
@@ -263,7 +261,7 @@ class VaultEncryptionHelperIntegrationTest {
 
         @Test
         void shouldViewEncryptedFile() {
-            var plainText = helper.viewFile(encryptedFile.toString());
+            var plainText = helper.viewFile(encryptedFile);
 
             assertThat(plainText).isEqualToNormalizingWhitespace(THE_SECRET);
         }
@@ -272,15 +270,14 @@ class VaultEncryptionHelperIntegrationTest {
         void shouldNotChangeEncryptedFile() throws IOException {
             var originalEncryptedContent = Files.readString(encryptedFile, StandardCharsets.UTF_8);
 
-            helper.viewFile(encryptedFile.toString());
+            helper.viewFile(encryptedFile);
 
             assertThat(encryptedFile).hasContent(originalEncryptedContent);
         }
 
         @Test
         void shouldThrowWhenGivenAnUnencryptedFile() throws IOException {
-            var plainTextFile = Files.writeString(Path.of(tempDir, "foo.txt"), "some plain text")
-                    .toString();
+            var plainTextFile = Files.writeString(Path.of(tempDir, "foo.txt"), "some plain text");
 
             assertThatThrownBy(() -> helper.viewFile(plainTextFile))
                     .isExactlyInstanceOf(VaultEncryptionException.class)
@@ -320,26 +317,23 @@ class VaultEncryptionHelperIntegrationTest {
 
         @Test
         void shouldRekeyAnEncryptedFile() {
-            var rekeyedFile = helper.rekeyFile(encryptedFile.toString(), newPasswordFile.toString());
-            var rekeyedFilePath = rekeyedFile.toString();
+            var rekeyedFile = helper.rekeyFile(encryptedFile, newPasswordFile);
 
-            assertThatThrownBy(() -> helper.viewFile(rekeyedFilePath))
+            assertThatThrownBy(() -> helper.viewFile(rekeyedFile))
                     .describedAs("Should not be able to decrypt using original password file")
                     .isExactlyInstanceOf(VaultEncryptionException.class)
                     .hasMessageStartingWith("ansible-vault returned non-zero exit code 1. Stderr: ");
 
             var newHelper = new VaultEncryptionHelper(newConfig);
-            var fileContent = newHelper.viewFile(rekeyedFilePath);
+            var fileContent = newHelper.viewFile(rekeyedFile);
             assertThat(fileContent).isEqualToNormalizingWhitespace(THE_SECRET);
         }
 
         @Test
         void shouldThrowWhenGivenAnUnencryptedFile() throws IOException {
-            var plainTextFile = Files.writeString(Path.of(tempDir, "foo.txt"), "some plain text")
-                    .toString();
-            var newPasswordFilePath = newPasswordFile.toString();
+            var plainTextFile = Files.writeString(Path.of(tempDir, "foo.txt"), "some plain text");
 
-            assertThatThrownBy(() -> helper.rekeyFile(plainTextFile, newPasswordFilePath))
+            assertThatThrownBy(() -> helper.rekeyFile(plainTextFile, newPasswordFile))
                     .isExactlyInstanceOf(VaultEncryptionException.class)
                     .hasMessageStartingWith("ansible-vault returned non-zero exit code 1. Stderr: ");
         }


### PR DESCRIPTION
The new methods are:
* Path encryptFile(Path plainTextFilePath)
* Path encryptFile(Path plainTextFilePath, String vaultIdLabel)
* Path decryptFile(Path encryptedFilePath)
* Path decryptFile(Path encryptedFilePath, Path outputFilePath)
* String viewFile(Path encryptedFilePath)
* Path rekeyFile(Path encryptedFilePath, Path newVaultPasswordFilePath)

They all just call the original methods that accept String, but this
provides more flexibility.

Fixed #50

cc @chrisrohr , @terezivy 