### PR TITLE
Add/enhance argument validation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -17,6 +17,9 @@
     </repositories>
 
     <properties>
+        <hibernate-validator.version>6.1.5.Final</hibernate-validator.version>
+        <jakarta.validation-api.version>2.0.2</jakarta.validation-api.version>
+        <jakarta-el.version>3.0.3</jakarta-el.version>
         <junit.jupiter.version>5.6.2</junit.jupiter.version>
         <assertj.version>3.16.1</assertj.version>
         <mockito.version>3.3.3</mockito.version>
@@ -33,6 +36,12 @@
             <groupId>org.kiwiproject</groupId>
             <artifactId>kiwi</artifactId>
             <version>0.7.0</version>
+        </dependency>
+
+        <dependency>
+            <groupId>jakarta.validation</groupId>
+            <artifactId>jakarta.validation-api</artifactId>
+            <version>${jakarta.validation-api.version}</version>
         </dependency>
 
         <dependency>
@@ -68,6 +77,21 @@
         </dependency>
 
         <!-- test deps -->
+
+        <dependency>
+            <groupId>org.hibernate.validator</groupId>
+            <artifactId>hibernate-validator</artifactId>
+            <version>${hibernate-validator.version}</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.glassfish</groupId>
+            <artifactId>jakarta.el</artifactId>
+            <version>${jakarta-el.version}</version>
+            <scope>test</scope>
+        </dependency>
+
 
         <dependency>
             <groupId>org.junit.jupiter</groupId>

--- a/src/main/java/org/example/ansible/vault/VaultConfiguration.java
+++ b/src/main/java/org/example/ansible/vault/VaultConfiguration.java
@@ -1,20 +1,32 @@
 package org.example.ansible.vault;
 
-import static java.util.Objects.isNull;
+import static org.apache.commons.lang3.StringUtils.isBlank;
+import static org.kiwiproject.base.KiwiPreconditions.requireNotBlank;
 
 import lombok.Builder;
 import lombok.Getter;
 import lombok.Setter;
 
+import javax.validation.constraints.NotBlank;
+
 /**
  * This is mutable in case it is used in injected configuration, e.g. in a Dropwizard configuration file.
+ * <p>
+ * Has beans validation annotations to support validation of external configuration, e.g. by Dropwizard's
+ * normal validation. But also uses explicit validation in the constructor used for the Lombok builder so
+ * that invalid configurations cannot be constructed via the builder.
  */
 @Getter
 @Setter
 public class VaultConfiguration {
 
+    @NotBlank
     private String ansibleVaultPath;
+
+    @NotBlank
     private String vaultPasswordFilePath;
+
+    @NotBlank
     private String tempDirectory;
 
     public VaultConfiguration() {
@@ -23,9 +35,9 @@ public class VaultConfiguration {
 
     @Builder
     public VaultConfiguration(String ansibleVaultPath, String vaultPasswordFilePath, String tempDirectory) {
-        this.ansibleVaultPath = ansibleVaultPath;
-        this.vaultPasswordFilePath = vaultPasswordFilePath;
-        this.tempDirectory = isNull(tempDirectory) ? getJavaTempDir() : tempDirectory;
+        this.ansibleVaultPath = requireNotBlank(ansibleVaultPath);
+        this.vaultPasswordFilePath = requireNotBlank(vaultPasswordFilePath);
+        this.tempDirectory = isBlank(tempDirectory) ? getJavaTempDir() : tempDirectory;
     }
 
     private String getJavaTempDir() {

--- a/src/main/java/org/example/ansible/vault/VaultDecryptCommand.java
+++ b/src/main/java/org/example/ansible/vault/VaultDecryptCommand.java
@@ -1,9 +1,12 @@
 package org.example.ansible.vault;
 
 import static java.util.Objects.nonNull;
+import static org.kiwiproject.base.KiwiPreconditions.checkArgumentNotBlank;
+import static org.kiwiproject.base.KiwiPreconditions.checkArgumentNotNull;
 
 import lombok.Builder;
 
+import javax.annotation.Nullable;
 import java.nio.file.Paths;
 import java.util.List;
 
@@ -27,7 +30,10 @@ public class VaultDecryptCommand implements OsCommand {
 
     public static VaultDecryptCommand from(VaultConfiguration configuration,
                                            String encryptedFilePath,
-                                           String outputFilePath) {
+                                           @Nullable String outputFilePath) {
+        checkArgumentNotNull(configuration, "configuration cannot be null");
+        checkArgumentNotBlank(encryptedFilePath, "encryptedFilePath cannot be blank");
+
         return VaultDecryptCommand.builder()
                 .ansibleVaultPath(configuration.getAnsibleVaultPath())
                 .vaultPasswordFilePath(configuration.getVaultPasswordFilePath())

--- a/src/main/java/org/example/ansible/vault/VaultEncryptCommand.java
+++ b/src/main/java/org/example/ansible/vault/VaultEncryptCommand.java
@@ -1,10 +1,13 @@
 package org.example.ansible.vault;
 
 import static java.util.Objects.isNull;
+import static org.kiwiproject.base.KiwiPreconditions.checkArgumentNotBlank;
+import static org.kiwiproject.base.KiwiPreconditions.checkArgumentNotNull;
 import static org.kiwiproject.base.KiwiStrings.f;
 
 import lombok.Builder;
 
+import javax.annotation.Nullable;
 import java.util.List;
 
 @Builder
@@ -20,8 +23,11 @@ public class VaultEncryptCommand implements OsCommand {
     }
 
     public static VaultEncryptCommand from(VaultConfiguration configuration,
-                                           String vaultIdLabel,
+                                           @Nullable String vaultIdLabel,
                                            String plainTextFilePath) {
+        checkArgumentNotNull(configuration, "configuration cannot be null");
+        checkArgumentNotBlank(plainTextFilePath, "plainTextFilePath cannot be blank");
+
         return VaultEncryptCommand.builder()
                 .ansibleVaultPath(configuration.getAnsibleVaultPath())
                 .vaultIdLabel(vaultIdLabel)

--- a/src/main/java/org/example/ansible/vault/VaultEncryptStringCommand.java
+++ b/src/main/java/org/example/ansible/vault/VaultEncryptStringCommand.java
@@ -1,10 +1,13 @@
 package org.example.ansible.vault;
 
 import static java.util.Objects.isNull;
+import static org.kiwiproject.base.KiwiPreconditions.checkArgumentNotBlank;
+import static org.kiwiproject.base.KiwiPreconditions.checkArgumentNotNull;
 import static org.kiwiproject.base.KiwiStrings.f;
 
 import lombok.Builder;
 
+import javax.annotation.Nullable;
 import java.util.List;
 
 @Builder
@@ -23,9 +26,13 @@ public class VaultEncryptStringCommand implements OsCommand {
     }
 
     public static VaultEncryptStringCommand from(VaultConfiguration configuration,
-                                                 String vaultIdLabel,
+                                                 @Nullable String vaultIdLabel,
                                                  String plainText,
                                                  String variableName) {
+        checkArgumentNotNull(configuration, "configuration cannot be null");
+        checkArgumentNotBlank(plainText, "plainText cannot be blank");
+        checkArgumentNotBlank(variableName, "variableName cannot be blank");
+
         return VaultEncryptStringCommand.builder()
                 .ansibleVaultPath(configuration.getAnsibleVaultPath())
                 .vaultIdLabel(vaultIdLabel)

--- a/src/main/java/org/example/ansible/vault/VaultEncryptedVariable.java
+++ b/src/main/java/org/example/ansible/vault/VaultEncryptedVariable.java
@@ -44,6 +44,7 @@ class VaultEncryptedVariable {
     private final String encryptedFileContent;
 
     VaultEncryptedVariable(String encryptedString) {
+        checkArgumentNotBlank(encryptedString, "encryptedString cannot be blank");
         parse(encryptedString);
         this.encryptedFileContent = buildEncryptedFileContent();
     }

--- a/src/main/java/org/example/ansible/vault/VaultEncryptionHelper.java
+++ b/src/main/java/org/example/ansible/vault/VaultEncryptionHelper.java
@@ -62,6 +62,7 @@ public class VaultEncryptionHelper {
      * Wraps the ansible-vault encrypt command. Encrypts file in place.
      */
     public Path encryptFile(Path plainTextFilePath) {
+        checkArgumentNotNull(plainTextFilePath, "plainTextFilePath cannot be null");
         return encryptFile(plainTextFilePath.toString());
     }
 
@@ -77,6 +78,7 @@ public class VaultEncryptionHelper {
      * Wraps the ansible-vault encrypt command using a vault ID label. Encrypts file in place.
      */
     public Path encryptFile(Path plainTextFilePath, String vaultIdLabel) {
+        checkArgumentNotNull(plainTextFilePath, "plainTextFilePath cannot be null");
         return encryptFile(plainTextFilePath.toString(), vaultIdLabel);
     }
 
@@ -92,6 +94,7 @@ public class VaultEncryptionHelper {
      * Wraps ansible-vault decrypt command. Decrypts file in place.
      */
     public Path decryptFile(Path encryptedFilePath) {
+        checkArgumentNotNull(encryptedFilePath, "encryptedFilePath cannot be null");
         return decryptFile(encryptedFilePath.toString());
     }
 
@@ -108,6 +111,8 @@ public class VaultEncryptionHelper {
      * The original encrypted file is not modified.
      */
     public Path decryptFile(Path encryptedFilePath, Path outputFilePath) {
+        checkArgumentNotNull(encryptedFilePath, "encryptedFilePath cannot be null");
+        checkArgumentNotNull(outputFilePath, "outputFilePath cannot be null");
         return decryptFile(encryptedFilePath.toString(), outputFilePath.toString());
     }
 
@@ -116,6 +121,8 @@ public class VaultEncryptionHelper {
      * The original encrypted file is not modified.
      */
     public Path decryptFile(String encryptedFilePath, String outputFilePath) {
+        checkArgumentNotBlank(encryptedFilePath, "encryptedFilePath cannot be blank");
+        checkArgumentNotBlank(outputFilePath, "outputFilePath cannot be blank");
         checkArgument(!outputFilePath.equalsIgnoreCase(encryptedFilePath),
                 "outputFilePath must be different than encryptedFilePath (case-insensitive)");
 
@@ -130,6 +137,7 @@ public class VaultEncryptionHelper {
      * The original encrypted file is not modified.
      */
     public String viewFile(Path encryptedFilePath) {
+        checkArgumentNotNull(encryptedFilePath, "encryptedFilePath cannot be null");
         return viewFile(encryptedFilePath.toString());
     }
 
@@ -146,6 +154,8 @@ public class VaultEncryptionHelper {
      * Wraps ansible-vault rekey command. Returns the path of the rekeyed file.
      */
     public Path rekeyFile(Path encryptedFilePath, Path newVaultPasswordFilePath) {
+        checkArgumentNotNull(encryptedFilePath, "encryptedFilePath cannot be null");
+        checkArgumentNotNull(newVaultPasswordFilePath, "newVaultPasswordFilePath cannot be null");
         return rekeyFile(encryptedFilePath.toString(), newVaultPasswordFilePath.toString());
     }
 
@@ -153,6 +163,8 @@ public class VaultEncryptionHelper {
      * Wraps ansible-vault rekey command. Returns the path of the rekeyed file.
      */
     public Path rekeyFile(String encryptedFilePath, String newVaultPasswordFilePath) {
+        checkArgumentNotBlank(encryptedFilePath, "encryptedFilePath cannot be blank");
+        checkArgumentNotBlank(newVaultPasswordFilePath, "newVaultPasswordFilePath cannot be blank");
         checkArgument(!newVaultPasswordFilePath.equalsIgnoreCase(configuration.getVaultPasswordFilePath()),
                 "newVaultPasswordFilePath file must be different than configuration.vaultPasswordFilePath (case-insensitive)");
 
@@ -174,7 +186,7 @@ public class VaultEncryptionHelper {
     }
 
     /**
-     * Wraps the ansible-vault encrypt_string command  using a vault ID label.
+     * Wraps the ansible-vault encrypt_string command  using an optional vault ID label.
      */
     public String encryptString(String vaultIdLabel, String plainText, String variableName) {
         var osCommand = VaultEncryptStringCommand.from(configuration, vaultIdLabel, plainText, variableName);

--- a/src/main/java/org/example/ansible/vault/VaultRekeyCommand.java
+++ b/src/main/java/org/example/ansible/vault/VaultRekeyCommand.java
@@ -1,5 +1,8 @@
 package org.example.ansible.vault;
 
+import static org.kiwiproject.base.KiwiPreconditions.checkArgumentNotBlank;
+import static org.kiwiproject.base.KiwiPreconditions.checkArgumentNotNull;
+
 import lombok.Builder;
 
 import java.nio.file.Paths;
@@ -16,6 +19,10 @@ public class VaultRekeyCommand implements OsCommand {
     public static VaultRekeyCommand from(VaultConfiguration configuration,
                                          String encryptedFilePath,
                                          String newVaultPasswordFilePath) {
+        checkArgumentNotNull(configuration, "configuration cannot be null");
+        checkArgumentNotBlank(encryptedFilePath, "encryptedFilePath cannot be blank");
+        checkArgumentNotBlank(newVaultPasswordFilePath, "newVaultPasswordFilePath cannot be blank");
+
         return VaultRekeyCommand.builder()
                 .ansibleVaultPath(configuration.getAnsibleVaultPath())
                 .vaultPasswordFilePath(configuration.getVaultPasswordFilePath())

--- a/src/main/java/org/example/ansible/vault/VaultViewCommand.java
+++ b/src/main/java/org/example/ansible/vault/VaultViewCommand.java
@@ -1,5 +1,8 @@
 package org.example.ansible.vault;
 
+import static org.kiwiproject.base.KiwiPreconditions.checkArgumentNotBlank;
+import static org.kiwiproject.base.KiwiPreconditions.checkArgumentNotNull;
+
 import lombok.Builder;
 
 import java.nio.file.Paths;
@@ -13,6 +16,9 @@ public class VaultViewCommand implements OsCommand {
     private final String encryptedFilePath;
 
     public static VaultViewCommand from(VaultConfiguration configuration, String encryptedFilePath) {
+        checkArgumentNotNull(configuration, "configuration cannot be null");
+        checkArgumentNotBlank(encryptedFilePath, "encryptedFilePath cannot be blank");
+
         return VaultViewCommand.builder()
                 .ansibleVaultPath(configuration.getAnsibleVaultPath())
                 .vaultPasswordFilePath(configuration.getVaultPasswordFilePath())


### PR DESCRIPTION
* Add Java Beans Validation annotations to VaultConfiguration to
  support validation via external configuration, e.g. a Dropwizard app
* Had to add several dependencies
* Add arg checks in XxxCommand factory methods; label any args that
  are not required with @Nullable
* Add arg checks in in VaultEncryptionHelper, mostly on the methods
  accepting Path args to avoid NPE when delegating to the overloaded
  String-based methods. Also, tried not to add redundant arg checking
  where it is already performed by the XxxCommand factory methods

Fixes #52